### PR TITLE
Support for JDK-14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,2 @@
 language: java
-jdk: openjdk6
+jdk: openjdk8

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-XtreemFS OpenDMK 1.0-b02-SNAPSHOT Build
+XtreemFS OpenDMK 1.0-b03-SNAPSHOT Build
 =======================================
 
-This project aims at providing `jdmkrt`, `jdmktk` and `jmxremote_optional` in a Maven structure. It is built from the 1.0-b02 Sources of [OpenDMK](https://opendmk.java.net/) using Maven 3.1.1 and Oracle JDK 1.5.0_13-b05, because the [binary plug](https://opendmk.java.net/download/index.html#BinaryComponents) (which this project uses) is built using this version as well.
+This project aims at providing `jdmkrt`, `jdmktk` and `jmxremote_optional` in a Maven structure. It is built from the 1.0-b03 Sources of [OpenDMK](https://opendmk.java.net/) using Maven 3.6.3 and Open JDK 14.0.1 with 1.8 bytecode.
 
 The SNAPSHOT build is available at this repository's [gh-pages](https://github.com/xtreemfs/opendmk/tree/gh-pages) and can be used as follows:
 
@@ -46,62 +46,62 @@ In your `pom.xml` add:
     <dependency>
       <groupId>org.xtreemfs.opendmk</groupId>
       <artifactId>jdmkrt</artifactId>
-      <version>1.0-b02-SNAPSHOT</version>
+      <version>1.0-b03-SNAPSHOT</version>
     </dependency>
     <!-- jdmkrt bundles the following artifacts -->
     <!--
     <dependency>
       <groupId>org.xtreemfs.opendmk</groupId>
       <artifactId>core</artifactId>
-      <version>1.0-b02-SNAPSHOT</version>
+      <version>1.0-b03-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.xtreemfs.opendmk</groupId>
       <artifactId>core-rmic</artifactId>
-      <version>1.0-b02-SNAPSHOT</version>
+      <version>1.0-b03-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.xtreemfs.opendmk</groupId>
       <artifactId>snmp_manager</artifactId>
-      <version>1.0-b02-SNAPSHOT</version>
+      <version>1.0-b03-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.xtreemfs.opendmk</groupId>
       <artifactId>snmp_agent</artifactId>
-      <version>1.0-b02-SNAPSHOT</version>
+      <version>1.0-b03-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.xtreemfs.opendmk</groupId>
       <artifactId>binary-plug</artifactId>
-      <version>1.0-b02</version>
+      <version>1.0-b03</version>
     </dependency>
     -->
     
     <dependency>
       <groupId>org.xtreemfs.opendmk</groupId>
       <artifactId>jdmktk</artifactId>
-      <version>1.0-b02-SNAPSHOT</version>
+      <version>1.0-b03-SNAPSHOT</version>
     </dependency>
     <!-- jdmktk bundles the following artifact -->
     <!--
     <dependency>
       <groupId>org.xtreemfs.opendmk</groupId>
       <artifactId>toolkit</artifactId>
-      <version>1.0-b02-SNAPSHOT</version>
+      <version>1.0-b03-SNAPSHOT</version>
     </dependency>
     -->
     
     <dependency>
       <groupId>org.xtreemfs.opendmk</groupId>
       <artifactId>jmxremote_optional</artifactId>
-      <version>1.0-b02-SNAPSHOT</version>
+      <version>1.0-b03-SNAPSHOT</version>
     </dependency>
     <!-- jmxremote_optional bundles the following artifact -->
     <!--
     <dependency>
       <groupId>org.xtreemfs.opendmk</groupId>
       <artifactId>jmx_optional</artifactId>
-      <version>1.0-b02-SNAPSHOT</version>
+      <version>1.0-b03-SNAPSHOT</version>
     </dependency>
     -->
   </dependencies>

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ XtreemFS OpenDMK 1.1-b02-SNAPSHOT Build
 
 This project aims at providing `jdmkrt`, `jdmktk` and `jmxremote_optional` in a Maven structure. It is built from the 1.0-b02 Sources of [OpenDMK](https://opendmk.java.net/) using Maven and Open JDK 14.0.1 with 1.8 bytecode.
 
-~~~ The SNAPSHOT build is available at this repository's [gh-pages](https://github.com/xtreemfs/opendmk/tree/gh-pages) and can be used as follows: ~~
+~~The SNAPSHOT build is available at this repository's [gh-pages](https://github.com/xtreemfs/opendmk/tree/gh-pages) and can be used as follows:~~
 
 In your `$HOME/.m2/settings.xml` add:
 ```XML
@@ -46,62 +46,62 @@ In your `pom.xml` add:
     <dependency>
       <groupId>org.xtreemfs.opendmk</groupId>
       <artifactId>jdmkrt</artifactId>
-      <version>1.1-b02-SNAPSHOT</version>
+      <version>1.0-b02-SNAPSHOT</version>
     </dependency>
     <!-- jdmkrt bundles the following artifacts -->
     <!--
     <dependency>
       <groupId>org.xtreemfs.opendmk</groupId>
       <artifactId>core</artifactId>
-      <version>1.1-b02-SNAPSHOT</version>
+      <version>1.0-b02-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.xtreemfs.opendmk</groupId>
       <artifactId>core-rmic</artifactId>
-      <version>1.1-b02-SNAPSHOT</version>
+      <version>1.0-b02-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.xtreemfs.opendmk</groupId>
       <artifactId>snmp_manager</artifactId>
-      <version>1.1-b02-SNAPSHOT</version>
+      <version>1.0-b02-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.xtreemfs.opendmk</groupId>
       <artifactId>snmp_agent</artifactId>
-      <version>1.1-b02-SNAPSHOT</version>
+      <version>1.0-b02-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.xtreemfs.opendmk</groupId>
       <artifactId>binary-plug</artifactId>
-      <version>1.1-b02</version>
+      <version>1.0-b02</version>
     </dependency>
     -->
     
     <dependency>
       <groupId>org.xtreemfs.opendmk</groupId>
       <artifactId>jdmktk</artifactId>
-      <version>1.1-b02-SNAPSHOT</version>
+      <version>1.0-b02-SNAPSHOT</version>
     </dependency>
     <!-- jdmktk bundles the following artifact -->
     <!--
     <dependency>
       <groupId>org.xtreemfs.opendmk</groupId>
       <artifactId>toolkit</artifactId>
-      <version>1.1-b02-SNAPSHOT</version>
+      <version>1.0-b02-SNAPSHOT</version>
     </dependency>
     -->
     
     <dependency>
       <groupId>org.xtreemfs.opendmk</groupId>
       <artifactId>jmxremote_optional</artifactId>
-      <version>1.1-b02-SNAPSHOT</version>
+      <version>1.0-b02-SNAPSHOT</version>
     </dependency>
     <!-- jmxremote_optional bundles the following artifact -->
     <!--
     <dependency>
       <groupId>org.xtreemfs.opendmk</groupId>
       <artifactId>jmx_optional</artifactId>
-      <version>1.1-b02-SNAPSHOT</version>
+      <version>1.0-b02-SNAPSHOT</version>
     </dependency>
     -->
   </dependencies>

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-XtreemFS OpenDMK 1.0-b03-SNAPSHOT Build
+XtreemFS OpenDMK 1.1-b02-SNAPSHOT Build
 =======================================
 
-This project aims at providing `jdmkrt`, `jdmktk` and `jmxremote_optional` in a Maven structure. It is built from the 1.0-b03 Sources of [OpenDMK](https://opendmk.java.net/) using Maven 3.6.3 and Open JDK 14.0.1 with 1.8 bytecode.
+This project aims at providing `jdmkrt`, `jdmktk` and `jmxremote_optional` in a Maven structure. It is built from the 1.0-b02 Sources of [OpenDMK](https://opendmk.java.net/) using Maven and Open JDK 14.0.1 with 1.8 bytecode.
 
-The SNAPSHOT build is available at this repository's [gh-pages](https://github.com/xtreemfs/opendmk/tree/gh-pages) and can be used as follows:
+~~~ The SNAPSHOT build is available at this repository's [gh-pages](https://github.com/xtreemfs/opendmk/tree/gh-pages) and can be used as follows: ~~
 
 In your `$HOME/.m2/settings.xml` add:
 ```XML
@@ -46,62 +46,62 @@ In your `pom.xml` add:
     <dependency>
       <groupId>org.xtreemfs.opendmk</groupId>
       <artifactId>jdmkrt</artifactId>
-      <version>1.0-b03-SNAPSHOT</version>
+      <version>1.1-b02-SNAPSHOT</version>
     </dependency>
     <!-- jdmkrt bundles the following artifacts -->
     <!--
     <dependency>
       <groupId>org.xtreemfs.opendmk</groupId>
       <artifactId>core</artifactId>
-      <version>1.0-b03-SNAPSHOT</version>
+      <version>1.1-b02-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.xtreemfs.opendmk</groupId>
       <artifactId>core-rmic</artifactId>
-      <version>1.0-b03-SNAPSHOT</version>
+      <version>1.1-b02-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.xtreemfs.opendmk</groupId>
       <artifactId>snmp_manager</artifactId>
-      <version>1.0-b03-SNAPSHOT</version>
+      <version>1.1-b02-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.xtreemfs.opendmk</groupId>
       <artifactId>snmp_agent</artifactId>
-      <version>1.0-b03-SNAPSHOT</version>
+      <version>1.1-b02-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.xtreemfs.opendmk</groupId>
       <artifactId>binary-plug</artifactId>
-      <version>1.0-b03</version>
+      <version>1.1-b02</version>
     </dependency>
     -->
     
     <dependency>
       <groupId>org.xtreemfs.opendmk</groupId>
       <artifactId>jdmktk</artifactId>
-      <version>1.0-b03-SNAPSHOT</version>
+      <version>1.1-b02-SNAPSHOT</version>
     </dependency>
     <!-- jdmktk bundles the following artifact -->
     <!--
     <dependency>
       <groupId>org.xtreemfs.opendmk</groupId>
       <artifactId>toolkit</artifactId>
-      <version>1.0-b03-SNAPSHOT</version>
+      <version>1.1-b02-SNAPSHOT</version>
     </dependency>
     -->
     
     <dependency>
       <groupId>org.xtreemfs.opendmk</groupId>
       <artifactId>jmxremote_optional</artifactId>
-      <version>1.0-b03-SNAPSHOT</version>
+      <version>1.1-b02-SNAPSHOT</version>
     </dependency>
     <!-- jmxremote_optional bundles the following artifact -->
     <!--
     <dependency>
       <groupId>org.xtreemfs.opendmk</groupId>
       <artifactId>jmx_optional</artifactId>
-      <version>1.0-b03-SNAPSHOT</version>
+      <version>1.1-b02-SNAPSHOT</version>
     </dependency>
     -->
   </dependencies>

--- a/jdmkrt/binary-plug/pom.xml
+++ b/jdmkrt/binary-plug/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.xtreemfs.opendmk</groupId>
     <artifactId>opendmk-jdmkrt</artifactId>
-    <version>1.0-b02-SNAPSHOT</version>
+    <version>1.0-b03-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/jdmkrt/binary-plug/pom.xml
+++ b/jdmkrt/binary-plug/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.xtreemfs.opendmk</groupId>
     <artifactId>opendmk-jdmkrt</artifactId>
-    <version>1.0-b03-SNAPSHOT</version>
+    <version>1.0-b02-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/jdmkrt/binary-plug/pom.xml
+++ b/jdmkrt/binary-plug/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.xtreemfs.opendmk</groupId>
     <artifactId>opendmk-jdmkrt</artifactId>
-    <version>1.0-b02-SNAPSHOT</version>
+    <version>1.1-b02-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/jdmkrt/binary-plug/src/main/resources/META-INF/MANIFEST.MF
+++ b/jdmkrt/binary-plug/src/main/resources/META-INF/MANIFEST.MF
@@ -10,6 +10,6 @@ Specification-Title: Java(TM) Dynamic Management Kit
 Specification-Version: 5.1
 Specification-Vendor: Sun Microsystems, Inc.
 Implementation-Title: Project OpenDMK, Binary Blugs
-Implementation-Version: opendmk-1.0-b02 2007.10.01_19:17:46_MEST
+Implementation-Version: opendmk-1.0-b03 2020.05.28_19:17:46_MEST
 Implementation-Vendor: Sun Microsystems, Inc
 

--- a/jdmkrt/binary-plug/src/main/resources/META-INF/MANIFEST.MF
+++ b/jdmkrt/binary-plug/src/main/resources/META-INF/MANIFEST.MF
@@ -10,6 +10,6 @@ Specification-Title: Java(TM) Dynamic Management Kit
 Specification-Version: 5.1
 Specification-Vendor: Sun Microsystems, Inc.
 Implementation-Title: Project OpenDMK, Binary Blugs
-Implementation-Version: opendmk-1.0-b03 2020.05.28_19:17:46_MEST
+Implementation-Version: opendmk-1.0-b02 2007.10.01_19:17:46_MEST
 Implementation-Vendor: Sun Microsystems, Inc
 

--- a/jdmkrt/core-rmic/pom.xml
+++ b/jdmkrt/core-rmic/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.xtreemfs.opendmk</groupId>
     <artifactId>opendmk-jdmkrt</artifactId>
-    <version>1.0-b03-SNAPSHOT</version>
+    <version>1.1-b02-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/jdmkrt/core-rmic/pom.xml
+++ b/jdmkrt/core-rmic/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.xtreemfs.opendmk</groupId>
     <artifactId>opendmk-jdmkrt</artifactId>
-    <version>1.0-b02-SNAPSHOT</version>
+    <version>1.0-b03-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/jdmkrt/core/pom.xml
+++ b/jdmkrt/core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.xtreemfs.opendmk</groupId>
     <artifactId>opendmk-jdmkrt</artifactId>
-    <version>1.0-b03-SNAPSHOT</version>
+    <version>1.1-b02-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/jdmkrt/core/pom.xml
+++ b/jdmkrt/core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.xtreemfs.opendmk</groupId>
     <artifactId>opendmk-jdmkrt</artifactId>
-    <version>1.0-b02-SNAPSHOT</version>
+    <version>1.0-b03-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/jdmkrt/core/src/main/java/com/sun/jdmk/ServiceName.java
+++ b/jdmkrt/core/src/main/java/com/sun/jdmk/ServiceName.java
@@ -4,19 +4,19 @@
  * @(#)version   1.123
  * @(#)lastedit  07/03/08
  *
- * 
+ *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
- * 
+ *
  * Copyright (c) 2007 Sun Microsystems, Inc. All Rights Reserved.
- * 
+ *
  * The contents of this file are subject to the terms of either the GNU General
  * Public License Version 2 only ("GPL") or the Common Development and
  * Distribution License("CDDL")(collectively, the "License"). You may not use
  * this file except in compliance with the License. You can obtain a copy of the
- * License at http://opendmk.dev.java.net/legal_notices/licenses.txt or in the 
- * LEGAL_NOTICES folder that accompanied this code. See the License for the 
+ * License at http://opendmk.dev.java.net/legal_notices/licenses.txt or in the
+ * LEGAL_NOTICES folder that accompanied this code. See the License for the
  * specific language governing permissions and limitations under the License.
- * 
+ *
  * When distributing the software, include this License Header Notice in each
  * file and include the License file found at
  *     http://opendmk.dev.java.net/legal_notices/licenses.txt
@@ -24,27 +24,27 @@
  * Sun designates this particular file as subject to the "Classpath" exception
  * as provided by Sun in the GPL Version 2 section of the License file that
  * accompanied this code.
- * 
+ *
  * If applicable, add the following below the License Header, with the fields
  * enclosed by brackets [] replaced by your own identifying information:
- * 
+ *
  *       "Portions Copyrighted [year] [name of copyright owner]"
- * 
+ *
  * Contributor(s):
- * 
+ *
  * If you wish your version of this file to be governed by only the CDDL or
  * only the GPL Version 2, indicate your decision by adding
- * 
+ *
  *       "[Contributor] elects to include this software in this distribution
  *        under the [CDDL or GPL Version 2] license."
- * 
+ *
  * If you don't indicate a single choice of license, a recipient has the option
  * to distribute your version of this file under either the CDDL or the GPL
  * Version 2, or to extend the choice of license to its licensees as provided
  * above. However, if you add GPL Version 2 code and therefore, elected the
  * GPL Version 2 license, then the option applies only if the new code is made
  * subject to such option by the copyright holder.
- * 
+ *
  */
 
 package com.sun.jdmk;
@@ -150,7 +150,7 @@ public class ServiceName {
     public static final String HTML_ADAPTOR_SERVER = "name=HtmlAdaptorServer" ;
 
     /**
-     * The name of the JMX specification implemented by this product.    
+     * The name of the JMX specification implemented by this product.
      * <BR>
      * The value is <CODE>Java Management Extensions</CODE>.
      */
@@ -164,7 +164,7 @@ public class ServiceName {
     public static final String JMX_SPEC_VERSION = "1.2 Maintenance Release";
 
     /**
-     * The vendor of the JMX specification implemented by this product.     
+     * The vendor of the JMX specification implemented by this product.
      * <BR>
      * The value is <CODE>Sun Microsystems</CODE>.
      */
@@ -178,22 +178,22 @@ public class ServiceName {
     public static final String JMX_IMPL_NAME = "Project OpenDMK";
 
     /**
-     * The name of the vendor of this product implementing the  JMX specification.  
+     * The name of the vendor of this product implementing the  JMX specification.
      * <BR>
      * The value is <CODE>Sun Microsystems</CODE>.
      */
     public static final String JMX_IMPL_VENDOR = "Sun Microsystems";
 
     /**
-      * The build number of the current product version, of the form 
+      * The build number of the current product version, of the form
       * <CODE>bXX</CODE>.
       */
-    public static final String BUILD_NUMBER = "b02";
+    public static final String BUILD_NUMBER = "b03";
 
     /**
-     * The version of this product implementing the  JMX specification.  
+     * The version of this product implementing the  JMX specification.
      * <BR>
-     * The value is <CODE>opendmk-1.0-bXX</CODE>, where <CODE>bXX</CODE> is the 
+     * The value is <CODE>opendmk-1.0-bXX</CODE>, where <CODE>bXX</CODE> is the
      * <CODE>BUILD_NUMBER</CODE> .
      */
     public static final String JMX_IMPL_VERSION = "opendmk-1.0-" + BUILD_NUMBER;

--- a/jdmkrt/core/src/main/java/com/sun/jdmk/ServiceName.java
+++ b/jdmkrt/core/src/main/java/com/sun/jdmk/ServiceName.java
@@ -188,14 +188,14 @@ public class ServiceName {
       * The build number of the current product version, of the form
       * <CODE>bXX</CODE>.
       */
-    public static final String BUILD_NUMBER = "b03";
+    public static final String BUILD_NUMBER = "b02";
 
     /**
      * The version of this product implementing the  JMX specification.
      * <BR>
-     * The value is <CODE>opendmk-1.0-bXX</CODE>, where <CODE>bXX</CODE> is the
+     * The value is <CODE>opendmk-1.1-bXX</CODE>, where <CODE>bXX</CODE> is the
      * <CODE>BUILD_NUMBER</CODE> .
      */
-    public static final String JMX_IMPL_VERSION = "opendmk-1.0-" + BUILD_NUMBER;
+    public static final String JMX_IMPL_VERSION = "opendmk-1.1-" + BUILD_NUMBER;
 
 }

--- a/jdmkrt/core/src/main/java/com/sun/jdmk/security/acl/Acl.java
+++ b/jdmkrt/core/src/main/java/com/sun/jdmk/security/acl/Acl.java
@@ -1,0 +1,217 @@
+package com.sun.jdmk.security.acl;
+
+import java.util.Enumeration;
+import java.security.Principal;
+
+
+/**
+ * Interface representing an Access Control List (ACL).  An Access
+ * Control List is a data structure used to guard access to
+ * resources.<p>
+ *
+ * An ACL can be thought of as a data structure with multiple ACL
+ * entries.  Each ACL entry, of interface type AclEntry, contains a
+ * set of permissions associated with a particular principal. (A
+ * principal represents an entity such as an individual user or a
+ * group). Additionally, each ACL entry is specified as being either
+ * positive or negative. If positive, the permissions are to be
+ * granted to the associated principal. If negative, the permissions
+ * are to be denied.<p>
+ *
+ * The ACL Entries in each ACL observe the following rules:
+ *
+ * <ul> <li>Each principal can have at most one positive ACL entry and
+ * one negative entry; that is, multiple positive or negative ACL
+ * entries are not allowed for any principal.  Each entry specifies
+ * the set of permissions that are to be granted (if positive) or
+ * denied (if negative).
+ *
+ * <li>If there is no entry for a particular principal, then the
+ * principal is considered to have a null (empty) permission set.
+ *
+ * <li>If there is a positive entry that grants a principal a
+ * particular permission, and a negative entry that denies the
+ * principal the same permission, the result is as though the
+ * permission was never granted or denied.
+ *
+ * <li>Individual permissions always override permissions of the
+ * group(s) to which the individual belongs. That is, individual
+ * negative permissions (specific denial of permissions) override the
+ * groups' positive permissions. And individual positive permissions
+ * override the groups' negative permissions.
+ *
+ * </ul>
+ *
+ * The {@code  com.sun.jdmk.security.acl } package provides the
+ * interfaces to the ACL and related data structures (ACL entries,
+ * groups, permissions, etc.), and the {@code  sun.security.acl }
+ * classes provide a default implementation of the interfaces. For
+ * example, {@code  com.sun.jdmk.security.acl.Acl } provides the
+ * interface to an ACL and the {@code  sun.security.acl.AclImpl }
+ * class provides the default implementation of the interface.<p>
+ *
+ * The {@code  com.sun.jdmk.security.acl.Acl } interface extends the
+ * {@code  com.sun.jdmk.security.acl.Owner } interface. The Owner
+ * interface is used to maintain a list of owners for each ACL.  Only
+ * owners are allowed to modify an ACL. For example, only an owner can
+ * call the ACL's {@code addEntry} method to add a new ACL entry
+ * to the ACL.
+ *
+ * @see com.sun.jdmk.security.acl.AclEntry
+ * @see com.sun.jdmk.security.acl.Owner
+ * @see com.sun.jdmk.security.acl.Acl#getPermissions
+ *
+ * @author Satish Dharmaraj
+ */
+
+public interface Acl extends Owner {
+
+    /**
+     * Sets the name of this ACL.
+     *
+     * @param caller the principal invoking this method. It must be an
+     * owner of this ACL.
+     *
+     * @param name the name to be given to this ACL.
+     *
+     * @exception NotOwnerException if the caller principal
+     * is not an owner of this ACL.
+     *
+     * @see #getName
+     */
+    public void setName(Principal caller, String name)
+	throws NotOwnerException;
+
+    /**
+     * Returns the name of this ACL.
+     *
+     * @return the name of this ACL.
+     *
+     * @see #setName
+     */
+    public String getName();
+
+    /**
+     * Adds an ACL entry to this ACL. An entry associates a principal
+     * (e.g., an individual or a group) with a set of
+     * permissions. Each principal can have at most one positive ACL
+     * entry (specifying permissions to be granted to the principal)
+     * and one negative ACL entry (specifying permissions to be
+     * denied). If there is already an ACL entry of the same type
+     * (negative or positive) already in the ACL, false is returned.
+     *
+     * @param caller the principal invoking this method. It must be an
+     * owner of this ACL.
+     *
+     * @param entry the ACL entry to be added to this ACL.
+     *
+     * @return true on success, false if an entry of the same type
+     * (positive or negative) for the same principal is already
+     * present in this ACL.
+     *
+     * @exception NotOwnerException if the caller principal
+     *  is not an owner of this ACL.
+     */
+    public boolean addEntry(Principal caller, AclEntry entry)
+	throws NotOwnerException;
+
+    /**
+     * Removes an ACL entry from this ACL.
+     *
+     * @param caller the principal invoking this method. It must be an
+     * owner of this ACL.
+     *
+     * @param entry the ACL entry to be removed from this ACL.
+     *
+     * @return true on success, false if the entry is not part of this ACL.
+     *
+     * @exception NotOwnerException if the caller principal is not
+     * an owner of this Acl.
+     */
+    public boolean removeEntry(Principal caller, AclEntry entry)
+	throws NotOwnerException;
+
+    /**
+     * Returns an enumeration for the set of allowed permissions for the
+     * specified principal (representing an entity such as an individual or
+     * a group). This set of allowed permissions is calculated as
+     * follows:
+     *
+     * <ul>
+     *
+     * <li>If there is no entry in this Access Control List for the
+     * specified principal, an empty permission set is returned.
+     *
+     * <li>Otherwise, the principal's group permission sets are determined.
+     * (A principal can belong to one or more groups, where a group is a
+     * group of principals, represented by the Group interface.)
+     * The group positive permission set is the union of all
+     * the positive permissions of each group that the principal belongs to.
+     * The group negative permission set is the union of all
+     * the negative permissions of each group that the principal belongs to.
+     * If there is a specific permission that occurs in both
+     * the positive permission set and the negative permission set,
+     * it is removed from both.<p>
+     *
+     * The individual positive and negative permission sets are also
+     * determined. The positive permission set contains the permissions
+     * specified in the positive ACL entry (if any) for the principal.
+     * Similarly, the negative permission set contains the permissions
+     * specified in the negative ACL entry (if any) for the principal.
+     * The individual positive (or negative) permission set is considered
+     * to be null if there is not a positive (negative) ACL entry for the
+     * principal in this ACL.<p>
+     *
+     * The set of permissions granted to the principal is then calculated
+     * using the simple rule that individual permissions always override
+     * the group permissions. That is, the principal's individual negative
+     * permission set (specific denial of permissions) overrides the group
+     * positive permission set, and the principal's individual positive
+     * permission set overrides the group negative permission set.
+     *
+     * </ul>
+     *
+     * @param user the principal whose permission set is to be returned.
+     *
+     * @return the permission set specifying the permissions the principal
+     * is allowed.
+     */
+    public Enumeration<Permission> getPermissions(Principal user);
+
+    /**
+     * Returns an enumeration of the entries in this ACL. Each element in
+     * the enumeration is of type AclEntry.
+     *
+     * @return an enumeration of the entries in this ACL.
+     */
+    public Enumeration<AclEntry> entries();
+
+    /**
+     * Checks whether or not the specified principal has the specified
+     * permission. If it does, true is returned, otherwise false is returned.
+     *
+     * More specifically, this method checks whether the passed permission
+     * is a member of the allowed permission set of the specified principal.
+     * The allowed permission set is determined by the same algorithm as is
+     * used by the {@code getPermissions} method.
+     *
+     * @param principal the principal, assumed to be a valid authenticated
+     * Principal.
+     *
+     * @param permission the permission to be checked for.
+     *
+     * @return true if the principal has the specified permission, false
+     * otherwise.
+     *
+     * @see #getPermissions
+     */
+    public boolean checkPermission(Principal principal, Permission permission);
+
+    /**
+     * Returns a string representation of the
+     * ACL contents.
+     *
+     * @return a string representation of the ACL contents.
+     */
+    public String toString();
+}

--- a/jdmkrt/core/src/main/java/com/sun/jdmk/security/acl/Acl.java
+++ b/jdmkrt/core/src/main/java/com/sun/jdmk/security/acl/Acl.java
@@ -3,215 +3,25 @@ package com.sun.jdmk.security.acl;
 import java.util.Enumeration;
 import java.security.Principal;
 
-
 /**
- * Interface representing an Access Control List (ACL).  An Access
- * Control List is a data structure used to guard access to
- * resources.<p>
- *
- * An ACL can be thought of as a data structure with multiple ACL
- * entries.  Each ACL entry, of interface type AclEntry, contains a
- * set of permissions associated with a particular principal. (A
- * principal represents an entity such as an individual user or a
- * group). Additionally, each ACL entry is specified as being either
- * positive or negative. If positive, the permissions are to be
- * granted to the associated principal. If negative, the permissions
- * are to be denied.<p>
- *
- * The ACL Entries in each ACL observe the following rules:
- *
- * <ul> <li>Each principal can have at most one positive ACL entry and
- * one negative entry; that is, multiple positive or negative ACL
- * entries are not allowed for any principal.  Each entry specifies
- * the set of permissions that are to be granted (if positive) or
- * denied (if negative).
- *
- * <li>If there is no entry for a particular principal, then the
- * principal is considered to have a null (empty) permission set.
- *
- * <li>If there is a positive entry that grants a principal a
- * particular permission, and a negative entry that denies the
- * principal the same permission, the result is as though the
- * permission was never granted or denied.
- *
- * <li>Individual permissions always override permissions of the
- * group(s) to which the individual belongs. That is, individual
- * negative permissions (specific denial of permissions) override the
- * groups' positive permissions. And individual positive permissions
- * override the groups' negative permissions.
- *
- * </ul>
- *
- * The {@code  com.sun.jdmk.security.acl } package provides the
- * interfaces to the ACL and related data structures (ACL entries,
- * groups, permissions, etc.), and the {@code  sun.security.acl }
- * classes provide a default implementation of the interfaces. For
- * example, {@code  com.sun.jdmk.security.acl.Acl } provides the
- * interface to an ACL and the {@code  sun.security.acl.AclImpl }
- * class provides the default implementation of the interface.<p>
- *
- * The {@code  com.sun.jdmk.security.acl.Acl } interface extends the
- * {@code  com.sun.jdmk.security.acl.Owner } interface. The Owner
- * interface is used to maintain a list of owners for each ACL.  Only
- * owners are allowed to modify an ACL. For example, only an owner can
- * call the ACL's {@code addEntry} method to add a new ACL entry
- * to the ACL.
- *
- * @see com.sun.jdmk.security.acl.AclEntry
- * @see com.sun.jdmk.security.acl.Owner
- * @see com.sun.jdmk.security.acl.Acl#getPermissions
- *
- * @author Satish Dharmaraj
+ * This interface replaces the deprecated java.security.acl interfaces.
  */
 
 public interface Acl extends Owner {
 
-    /**
-     * Sets the name of this ACL.
-     *
-     * @param caller the principal invoking this method. It must be an
-     * owner of this ACL.
-     *
-     * @param name the name to be given to this ACL.
-     *
-     * @exception NotOwnerException if the caller principal
-     * is not an owner of this ACL.
-     *
-     * @see #getName
-     */
-    public void setName(Principal caller, String name)
-	throws NotOwnerException;
+    void setName(Principal caller, String name) throws NotOwnerException;
 
-    /**
-     * Returns the name of this ACL.
-     *
-     * @return the name of this ACL.
-     *
-     * @see #setName
-     */
-    public String getName();
+    String getName();
 
-    /**
-     * Adds an ACL entry to this ACL. An entry associates a principal
-     * (e.g., an individual or a group) with a set of
-     * permissions. Each principal can have at most one positive ACL
-     * entry (specifying permissions to be granted to the principal)
-     * and one negative ACL entry (specifying permissions to be
-     * denied). If there is already an ACL entry of the same type
-     * (negative or positive) already in the ACL, false is returned.
-     *
-     * @param caller the principal invoking this method. It must be an
-     * owner of this ACL.
-     *
-     * @param entry the ACL entry to be added to this ACL.
-     *
-     * @return true on success, false if an entry of the same type
-     * (positive or negative) for the same principal is already
-     * present in this ACL.
-     *
-     * @exception NotOwnerException if the caller principal
-     *  is not an owner of this ACL.
-     */
-    public boolean addEntry(Principal caller, AclEntry entry)
-	throws NotOwnerException;
+    boolean addEntry(Principal caller, AclEntry entry) throws NotOwnerException;
 
-    /**
-     * Removes an ACL entry from this ACL.
-     *
-     * @param caller the principal invoking this method. It must be an
-     * owner of this ACL.
-     *
-     * @param entry the ACL entry to be removed from this ACL.
-     *
-     * @return true on success, false if the entry is not part of this ACL.
-     *
-     * @exception NotOwnerException if the caller principal is not
-     * an owner of this Acl.
-     */
-    public boolean removeEntry(Principal caller, AclEntry entry)
-	throws NotOwnerException;
+    boolean removeEntry(Principal caller, AclEntry entry) throws NotOwnerException;
 
-    /**
-     * Returns an enumeration for the set of allowed permissions for the
-     * specified principal (representing an entity such as an individual or
-     * a group). This set of allowed permissions is calculated as
-     * follows:
-     *
-     * <ul>
-     *
-     * <li>If there is no entry in this Access Control List for the
-     * specified principal, an empty permission set is returned.
-     *
-     * <li>Otherwise, the principal's group permission sets are determined.
-     * (A principal can belong to one or more groups, where a group is a
-     * group of principals, represented by the Group interface.)
-     * The group positive permission set is the union of all
-     * the positive permissions of each group that the principal belongs to.
-     * The group negative permission set is the union of all
-     * the negative permissions of each group that the principal belongs to.
-     * If there is a specific permission that occurs in both
-     * the positive permission set and the negative permission set,
-     * it is removed from both.<p>
-     *
-     * The individual positive and negative permission sets are also
-     * determined. The positive permission set contains the permissions
-     * specified in the positive ACL entry (if any) for the principal.
-     * Similarly, the negative permission set contains the permissions
-     * specified in the negative ACL entry (if any) for the principal.
-     * The individual positive (or negative) permission set is considered
-     * to be null if there is not a positive (negative) ACL entry for the
-     * principal in this ACL.<p>
-     *
-     * The set of permissions granted to the principal is then calculated
-     * using the simple rule that individual permissions always override
-     * the group permissions. That is, the principal's individual negative
-     * permission set (specific denial of permissions) overrides the group
-     * positive permission set, and the principal's individual positive
-     * permission set overrides the group negative permission set.
-     *
-     * </ul>
-     *
-     * @param user the principal whose permission set is to be returned.
-     *
-     * @return the permission set specifying the permissions the principal
-     * is allowed.
-     */
-    public Enumeration<Permission> getPermissions(Principal user);
+    Enumeration<Permission> getPermissions(Principal user);
 
-    /**
-     * Returns an enumeration of the entries in this ACL. Each element in
-     * the enumeration is of type AclEntry.
-     *
-     * @return an enumeration of the entries in this ACL.
-     */
-    public Enumeration<AclEntry> entries();
+    Enumeration<AclEntry> entries();
 
-    /**
-     * Checks whether or not the specified principal has the specified
-     * permission. If it does, true is returned, otherwise false is returned.
-     *
-     * More specifically, this method checks whether the passed permission
-     * is a member of the allowed permission set of the specified principal.
-     * The allowed permission set is determined by the same algorithm as is
-     * used by the {@code getPermissions} method.
-     *
-     * @param principal the principal, assumed to be a valid authenticated
-     * Principal.
-     *
-     * @param permission the permission to be checked for.
-     *
-     * @return true if the principal has the specified permission, false
-     * otherwise.
-     *
-     * @see #getPermissions
-     */
-    public boolean checkPermission(Principal principal, Permission permission);
+    boolean checkPermission(Principal principal, Permission permission);
 
-    /**
-     * Returns a string representation of the
-     * ACL contents.
-     *
-     * @return a string representation of the ACL contents.
-     */
-    public String toString();
+    String toString();
 }

--- a/jdmkrt/core/src/main/java/com/sun/jdmk/security/acl/AclEntry.java
+++ b/jdmkrt/core/src/main/java/com/sun/jdmk/security/acl/AclEntry.java
@@ -1,0 +1,106 @@
+package com.sun.jdmk.security.acl;
+
+import java.util.Enumeration;
+import java.security.Principal;
+
+public interface AclEntry extends Cloneable {
+
+    /**
+     * Specifies the principal for which permissions are granted or denied
+     * by this ACL entry. If a principal was already set for this ACL entry,
+     * false is returned, otherwise true is returned.
+     *
+     * @param user the principal to be set for this entry.
+     *
+     * @return true if the principal is set, false if there was
+     * already a principal set for this entry.
+     *
+     * @see #getPrincipal
+     */
+    public boolean setPrincipal(Principal user);
+
+    /**
+     * Returns the principal for which permissions are granted or denied by
+     * this ACL entry. Returns null if there is no principal set for this
+     * entry yet.
+     *
+     * @return the principal associated with this entry.
+     *
+     * @see #setPrincipal
+     */
+    public Principal getPrincipal();
+
+    /**
+     * Sets this ACL entry to be a negative one. That is, the associated
+     * principal (e.g., a user or a group) will be denied the permission set
+     * specified in the entry.
+     *
+     * Note: ACL entries are by default positive. An entry becomes a
+     * negative entry only if this {@code setNegativePermissions}
+     * method is called on it.
+     */
+    public void setNegativePermissions();
+
+    /**
+     * Returns true if this is a negative ACL entry (one denying the
+     * associated principal the set of permissions in the entry), false
+     * otherwise.
+     *
+     * @return true if this is a negative ACL entry, false if it's not.
+     */
+    public boolean isNegative();
+
+    /**
+     * Adds the specified permission to this ACL entry. Note: An entry can
+     * have multiple permissions.
+     *
+     * @param permission the permission to be associated with
+     * the principal in this entry.
+     *
+     * @return true if the permission was added, false if the
+     * permission was already part of this entry's permission set.
+     */
+    public boolean addPermission(Permission permission);
+
+    /**
+     * Removes the specified permission from this ACL entry.
+     *
+     * @param permission the permission to be removed from this entry.
+     *
+     * @return true if the permission is removed, false if the
+     * permission was not part of this entry's permission set.
+     */
+    public boolean removePermission(Permission permission);
+
+    /**
+     * Checks if the specified permission is part of the
+     * permission set in this entry.
+     *
+     * @param permission the permission to be checked for.
+     *
+     * @return true if the permission is part of the
+     * permission set in this entry, false otherwise.
+     */
+    public boolean checkPermission(Permission permission);
+
+    /**
+     * Returns an enumeration of the permissions in this ACL entry.
+     *
+     * @return an enumeration of the permissions in this ACL entry.
+     */
+    public Enumeration<Permission> permissions();
+
+    /**
+     * Returns a string representation of the contents of this ACL entry.
+     *
+     * @return a string representation of the contents.
+     */
+    public String toString();
+
+    /**
+     * Clones this ACL entry.
+     *
+     * @return a clone of this ACL entry.
+     */
+    public Object clone();
+}

--- a/jdmkrt/core/src/main/java/com/sun/jdmk/security/acl/AclEntry.java
+++ b/jdmkrt/core/src/main/java/com/sun/jdmk/security/acl/AclEntry.java
@@ -3,104 +3,29 @@ package com.sun.jdmk.security.acl;
 import java.util.Enumeration;
 import java.security.Principal;
 
+/**
+ * This interface replaces the deprecated java.security.acl interfaces.
+ */
+
 public interface AclEntry extends Cloneable {
 
-    /**
-     * Specifies the principal for which permissions are granted or denied
-     * by this ACL entry. If a principal was already set for this ACL entry,
-     * false is returned, otherwise true is returned.
-     *
-     * @param user the principal to be set for this entry.
-     *
-     * @return true if the principal is set, false if there was
-     * already a principal set for this entry.
-     *
-     * @see #getPrincipal
-     */
-    public boolean setPrincipal(Principal user);
+    boolean setPrincipal(Principal user);
 
-    /**
-     * Returns the principal for which permissions are granted or denied by
-     * this ACL entry. Returns null if there is no principal set for this
-     * entry yet.
-     *
-     * @return the principal associated with this entry.
-     *
-     * @see #setPrincipal
-     */
-    public Principal getPrincipal();
+    Principal getPrincipal();
 
-    /**
-     * Sets this ACL entry to be a negative one. That is, the associated
-     * principal (e.g., a user or a group) will be denied the permission set
-     * specified in the entry.
-     *
-     * Note: ACL entries are by default positive. An entry becomes a
-     * negative entry only if this {@code setNegativePermissions}
-     * method is called on it.
-     */
-    public void setNegativePermissions();
+    void setNegativePermissions();
 
-    /**
-     * Returns true if this is a negative ACL entry (one denying the
-     * associated principal the set of permissions in the entry), false
-     * otherwise.
-     *
-     * @return true if this is a negative ACL entry, false if it's not.
-     */
-    public boolean isNegative();
+    boolean isNegative();
 
-    /**
-     * Adds the specified permission to this ACL entry. Note: An entry can
-     * have multiple permissions.
-     *
-     * @param permission the permission to be associated with
-     * the principal in this entry.
-     *
-     * @return true if the permission was added, false if the
-     * permission was already part of this entry's permission set.
-     */
-    public boolean addPermission(Permission permission);
+    boolean addPermission(Permission permission);
 
-    /**
-     * Removes the specified permission from this ACL entry.
-     *
-     * @param permission the permission to be removed from this entry.
-     *
-     * @return true if the permission is removed, false if the
-     * permission was not part of this entry's permission set.
-     */
-    public boolean removePermission(Permission permission);
+    boolean removePermission(Permission permission);
 
-    /**
-     * Checks if the specified permission is part of the
-     * permission set in this entry.
-     *
-     * @param permission the permission to be checked for.
-     *
-     * @return true if the permission is part of the
-     * permission set in this entry, false otherwise.
-     */
-    public boolean checkPermission(Permission permission);
+    boolean checkPermission(Permission permission);
 
-    /**
-     * Returns an enumeration of the permissions in this ACL entry.
-     *
-     * @return an enumeration of the permissions in this ACL entry.
-     */
-    public Enumeration<Permission> permissions();
+    Enumeration<Permission> permissions();
 
-    /**
-     * Returns a string representation of the contents of this ACL entry.
-     *
-     * @return a string representation of the contents.
-     */
-    public String toString();
+    String toString();
 
-    /**
-     * Clones this ACL entry.
-     *
-     * @return a clone of this ACL entry.
-     */
-    public Object clone();
+    Object clone();
 }

--- a/jdmkrt/core/src/main/java/com/sun/jdmk/security/acl/Group.java
+++ b/jdmkrt/core/src/main/java/com/sun/jdmk/security/acl/Group.java
@@ -4,59 +4,16 @@ import java.util.Enumeration;
 import java.security.Principal;
 
 /**
- * This interface is used to represent a group of principals. (A principal
- * represents an entity such as an individual user or a company). <p>
- *
- * Note that Group extends Principal. Thus, either a Principal or a Group can
- * be passed as an argument to methods containing a Principal parameter. For
- * example, you can add either a Principal or a Group to a Group object by
- * calling the object's {@code addMember} method, passing it the
- * Principal or Group.
- *
+ * This interface replaces the deprecated java.security.acl interfaces.
  */
 
 public interface Group extends Principal {
 
-    /**
-     * Adds the specified member to the group.
-     *
-     * @param user the principal to add to this group.
-     *
-     * @return true if the member was successfully added,
-     * false if the principal was already a member.
-     */
-    public boolean addMember(Principal user);
+    boolean addMember(Principal user);
 
-    /**
-     * Removes the specified member from the group.
-     *
-     * @param user the principal to remove from this group.
-     *
-     * @return true if the principal was removed, or
-     * false if the principal was not a member.
-     */
-    public boolean removeMember(Principal user);
+    boolean removeMember(Principal user);
 
-    /**
-     * Returns true if the passed principal is a member of the group.
-     * This method does a recursive search, so if a principal belongs to a
-     * group which is a member of this group, true is returned.
-     *
-     * @param member the principal whose membership is to be checked.
-     *
-     * @return true if the principal is a member of this group,
-     * false otherwise.
-     */
-    public boolean isMember(Principal member);
+    boolean isMember(Principal member);
 
-
-    /**
-     * Returns an enumeration of the members in the group.
-     * The returned objects can be instances of either Principal
-     * or Group (which is a subclass of Principal).
-     *
-     * @return an enumeration of the group members.
-     */
-    public Enumeration<? extends Principal> members();
-
+    Enumeration<? extends Principal> members();
 }

--- a/jdmkrt/core/src/main/java/com/sun/jdmk/security/acl/Group.java
+++ b/jdmkrt/core/src/main/java/com/sun/jdmk/security/acl/Group.java
@@ -1,0 +1,62 @@
+package com.sun.jdmk.security.acl;
+
+import java.util.Enumeration;
+import java.security.Principal;
+
+/**
+ * This interface is used to represent a group of principals. (A principal
+ * represents an entity such as an individual user or a company). <p>
+ *
+ * Note that Group extends Principal. Thus, either a Principal or a Group can
+ * be passed as an argument to methods containing a Principal parameter. For
+ * example, you can add either a Principal or a Group to a Group object by
+ * calling the object's {@code addMember} method, passing it the
+ * Principal or Group.
+ *
+ */
+
+public interface Group extends Principal {
+
+    /**
+     * Adds the specified member to the group.
+     *
+     * @param user the principal to add to this group.
+     *
+     * @return true if the member was successfully added,
+     * false if the principal was already a member.
+     */
+    public boolean addMember(Principal user);
+
+    /**
+     * Removes the specified member from the group.
+     *
+     * @param user the principal to remove from this group.
+     *
+     * @return true if the principal was removed, or
+     * false if the principal was not a member.
+     */
+    public boolean removeMember(Principal user);
+
+    /**
+     * Returns true if the passed principal is a member of the group.
+     * This method does a recursive search, so if a principal belongs to a
+     * group which is a member of this group, true is returned.
+     *
+     * @param member the principal whose membership is to be checked.
+     *
+     * @return true if the principal is a member of this group,
+     * false otherwise.
+     */
+    public boolean isMember(Principal member);
+
+
+    /**
+     * Returns an enumeration of the members in the group.
+     * The returned objects can be instances of either Principal
+     * or Group (which is a subclass of Principal).
+     *
+     * @return an enumeration of the group members.
+     */
+    public Enumeration<? extends Principal> members();
+
+}

--- a/jdmkrt/core/src/main/java/com/sun/jdmk/security/acl/LastOwnerException.java
+++ b/jdmkrt/core/src/main/java/com/sun/jdmk/security/acl/LastOwnerException.java
@@ -1,0 +1,8 @@
+package com.sun.jdmk.security.acl;
+
+public class LastOwnerException extends Exception {
+
+    private static final long serialVersionUID = -5141997548211140359L;
+
+    public LastOwnerException() {}
+}

--- a/jdmkrt/core/src/main/java/com/sun/jdmk/security/acl/LastOwnerException.java
+++ b/jdmkrt/core/src/main/java/com/sun/jdmk/security/acl/LastOwnerException.java
@@ -1,8 +1,13 @@
 package com.sun.jdmk.security.acl;
 
+/**
+ * A replacement for the deprecated java.security.acl.LastOwnerException
+ */
+
+
 public class LastOwnerException extends Exception {
 
-    private static final long serialVersionUID = -5141997548211140359L;
+    private static final long serialVersionUID = -8099200969877636933L;
 
     public LastOwnerException() {}
 }

--- a/jdmkrt/core/src/main/java/com/sun/jdmk/security/acl/NotOwnerException.java
+++ b/jdmkrt/core/src/main/java/com/sun/jdmk/security/acl/NotOwnerException.java
@@ -1,0 +1,8 @@
+package com.sun.jdmk.security.acl;
+
+public class NotOwnerException extends Exception {
+
+    private static final long serialVersionUID = -5555597911163362399L;
+
+    public NotOwnerException() {}
+}

--- a/jdmkrt/core/src/main/java/com/sun/jdmk/security/acl/NotOwnerException.java
+++ b/jdmkrt/core/src/main/java/com/sun/jdmk/security/acl/NotOwnerException.java
@@ -1,8 +1,12 @@
 package com.sun.jdmk.security.acl;
 
+/**
+ * A replacement for the deprecated java.security.acl.NotOwnerException
+ */
+
 public class NotOwnerException extends Exception {
 
-    private static final long serialVersionUID = -5555597911163362399L;
+    private static final long serialVersionUID = 3382143188777171891L;
 
     public NotOwnerException() {}
 }

--- a/jdmkrt/core/src/main/java/com/sun/jdmk/security/acl/Owner.java
+++ b/jdmkrt/core/src/main/java/com/sun/jdmk/security/acl/Owner.java
@@ -1,0 +1,9 @@
+package com.sun.jdmk.security.acl;
+
+import java.security.Principal;
+
+public interface Owner {
+
+    boolean addOwner​(Principal caller, Principal owner)
+	throws NotOwnerException;
+}

--- a/jdmkrt/core/src/main/java/com/sun/jdmk/security/acl/Owner.java
+++ b/jdmkrt/core/src/main/java/com/sun/jdmk/security/acl/Owner.java
@@ -2,6 +2,10 @@ package com.sun.jdmk.security.acl;
 
 import java.security.Principal;
 
+/**
+ * This interface replaces the deprecated java.security.acl interfaces.
+ */
+
 public interface Owner {
 
     boolean addOwner​(Principal caller, Principal owner)

--- a/jdmkrt/core/src/main/java/com/sun/jdmk/security/acl/Permission.java
+++ b/jdmkrt/core/src/main/java/com/sun/jdmk/security/acl/Permission.java
@@ -1,0 +1,22 @@
+package com.sun.jdmk.security.acl;
+
+public interface Permission {
+
+    /**
+     * Returns true if the object passed matches the permission represented
+     * in this interface.
+     *
+     * @param another the Permission object to compare with.
+     *
+     * @return true if the Permission objects are equal, false otherwise
+     */
+    public boolean equals(Object another);
+
+    /**
+     * Prints a string representation of this permission.
+     *
+     * @return the string representation of the permission.
+     */
+    public String toString();
+
+}

--- a/jdmkrt/core/src/main/java/com/sun/jdmk/security/acl/Permission.java
+++ b/jdmkrt/core/src/main/java/com/sun/jdmk/security/acl/Permission.java
@@ -1,22 +1,12 @@
 package com.sun.jdmk.security.acl;
 
+/**
+ * This interface replaces the deprecated java.security.acl interfaces.
+ */
+
 public interface Permission {
 
-    /**
-     * Returns true if the object passed matches the permission represented
-     * in this interface.
-     *
-     * @param another the Permission object to compare with.
-     *
-     * @return true if the Permission objects are equal, false otherwise
-     */
-    public boolean equals(Object another);
+    boolean equals(Object another);
 
-    /**
-     * Prints a string representation of this permission.
-     *
-     * @return the string representation of the permission.
-     */
-    public String toString();
-
+    String toString();
 }

--- a/jdmkrt/jdmkrt-dist/pom.xml
+++ b/jdmkrt/jdmkrt-dist/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.xtreemfs.opendmk</groupId>
     <artifactId>opendmk-jdmkrt</artifactId>
-    <version>1.0-b03-SNAPSHOT</version>
+    <version>1.1-b02-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/jdmkrt/jdmkrt-dist/pom.xml
+++ b/jdmkrt/jdmkrt-dist/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.xtreemfs.opendmk</groupId>
     <artifactId>opendmk-jdmkrt</artifactId>
-    <version>1.0-b02-SNAPSHOT</version>
+    <version>1.0-b03-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/jdmkrt/jdmkrt-dist/src/main/resources/META-INF/README.html
+++ b/jdmkrt/jdmkrt-dist/src/main/resources/META-INF/README.html
@@ -16,7 +16,7 @@
         </center>
 
         <center>
-            <b>Build opendmk-1.0-b03</b>
+            <b>Build opendmk-1.1-b02</b>
         </center>
 
 
@@ -195,7 +195,7 @@
                     <font size=-1><a href="LEGAL_NOTICES/COPYRIGHT">Copyright &copy; 1998-2007 Sun Microsystems, Inc.</a> All rights reserved. Use is subject to <a href="LEGAL_NOTICES/license.txt">license</a> terms.</font>
                 </td>
                 <td align="RIGHT">
-                    <i><font size=-1>build opendmk-1.0-b03</font></i>
+                    <i><font size=-1>build opendmk-1.1-b02</font></i>
                 </td>
             </tr>
         </table>

--- a/jdmkrt/jdmkrt-dist/src/main/resources/META-INF/README.html
+++ b/jdmkrt/jdmkrt-dist/src/main/resources/META-INF/README.html
@@ -16,7 +16,7 @@
         </center>
 
         <center>
-            <b>Build opendmk-1.0-b02</b>
+            <b>Build opendmk-1.0-b03</b>
         </center>
 
 
@@ -195,7 +195,7 @@
                     <font size=-1><a href="LEGAL_NOTICES/COPYRIGHT">Copyright &copy; 1998-2007 Sun Microsystems, Inc.</a> All rights reserved. Use is subject to <a href="LEGAL_NOTICES/license.txt">license</a> terms.</font>
                 </td>
                 <td align="RIGHT">
-                    <i><font size=-1>build opendmk-1.0-b02</font></i>
+                    <i><font size=-1>build opendmk-1.0-b03</font></i>
                 </td>
             </tr>
         </table>

--- a/jdmkrt/pom.xml
+++ b/jdmkrt/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.xtreemfs.opendmk</groupId>
     <artifactId>opendmk-parent</artifactId>
-    <version>1.0-b02-SNAPSHOT</version>
+    <version>1.0-b03-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/jdmkrt/pom.xml
+++ b/jdmkrt/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.xtreemfs.opendmk</groupId>
     <artifactId>opendmk-parent</artifactId>
-    <version>1.0-b03-SNAPSHOT</version>
+    <version>1.1-b02-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/jdmkrt/snmp_agent/pom.xml
+++ b/jdmkrt/snmp_agent/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.xtreemfs.opendmk</groupId>
     <artifactId>opendmk-jdmkrt</artifactId>
-    <version>1.0-b03-SNAPSHOT</version>
+    <version>1.1-b02-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/jdmkrt/snmp_agent/pom.xml
+++ b/jdmkrt/snmp_agent/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.xtreemfs.opendmk</groupId>
     <artifactId>opendmk-jdmkrt</artifactId>
-    <version>1.0-b02-SNAPSHOT</version>
+    <version>1.0-b03-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/jdmkrt/snmp_manager/pom.xml
+++ b/jdmkrt/snmp_manager/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.xtreemfs.opendmk</groupId>
     <artifactId>opendmk-jdmkrt</artifactId>
-    <version>1.0-b03-SNAPSHOT</version>
+    <version>1.1-b02-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/jdmkrt/snmp_manager/pom.xml
+++ b/jdmkrt/snmp_manager/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.xtreemfs.opendmk</groupId>
     <artifactId>opendmk-jdmkrt</artifactId>
-    <version>1.0-b02-SNAPSHOT</version>
+    <version>1.0-b03-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/jdmkrt/snmp_manager/src/main/java/com/sun/management/snmp/IPAcl/AclEntryImpl.java
+++ b/jdmkrt/snmp_manager/src/main/java/com/sun/management/snmp/IPAcl/AclEntryImpl.java
@@ -4,19 +4,19 @@
  * @(#)version   4.15
  * @(#)date      07/10/01
  *
- * 
+ *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
- * 
+ *
  * Copyright (c) 2007 Sun Microsystems, Inc. All Rights Reserved.
- * 
+ *
  * The contents of this file are subject to the terms of either the GNU General
  * Public License Version 2 only ("GPL") or the Common Development and
  * Distribution License("CDDL")(collectively, the "License"). You may not use
  * this file except in compliance with the License. You can obtain a copy of the
- * License at http://opendmk.dev.java.net/legal_notices/licenses.txt or in the 
- * LEGAL_NOTICES folder that accompanied this code. See the License for the 
+ * License at http://opendmk.dev.java.net/legal_notices/licenses.txt or in the
+ * LEGAL_NOTICES folder that accompanied this code. See the License for the
  * specific language governing permissions and limitations under the License.
- * 
+ *
  * When distributing the software, include this License Header Notice in each
  * file and include the License file found at
  *     http://opendmk.dev.java.net/legal_notices/licenses.txt
@@ -24,27 +24,27 @@
  * Sun designates this particular file as subject to the "Classpath" exception
  * as provided by Sun in the GPL Version 2 section of the License file that
  * accompanied this code.
- * 
+ *
  * If applicable, add the following below the License Header, with the fields
  * enclosed by brackets [] replaced by your own identifying information:
- * 
+ *
  *       "Portions Copyrighted [year] [name of copyright owner]"
- * 
+ *
  * Contributor(s):
- * 
+ *
  * If you wish your version of this file to be governed by only the CDDL or
  * only the GPL Version 2, indicate your decision by adding
- * 
+ *
  *       "[Contributor] elects to include this software in this distribution
  *        under the [CDDL or GPL Version 2] license."
- * 
+ *
  * If you don't indicate a single choice of license, a recipient has the option
  * to distribute your version of this file under either the CDDL or the GPL
  * Version 2, or to extend the choice of license to its licensees as provided
  * above. However, if you add GPL Version 2 code and therefore, elected the
  * GPL Version 2 license, then the option applies only if the new code is made
  * subject to such option by the copyright holder.
- * 
+ *
  *
  */
 
@@ -58,39 +58,39 @@ import java.util.Enumeration;
 import java.io.Serializable;
 import java.net.UnknownHostException;
 
-import java.security.Principal; 
-import java.security.acl.AclEntry; 
+import java.security.Principal;
+import com.sun.jdmk.security.acl.AclEntry;
 
 
 /**
  * Represent one entry in the Access Control List (ACL).
- * This ACL entry object contains a permission associated with a particular 
+ * This ACL entry object contains a permission associated with a particular
  * principal.
  * (A principal represents an entity such as an individual machine or a group).
  *
- * @see java.security.acl.AclEntry
+ * @see com.sun.jdmk.security.acl.AclEntry
  *
  * @since Java DMK 5.1
  */
 
 class AclEntryImpl implements AclEntry, Serializable {
     private static final long serialVersionUID = 356147207463306787L;
-  
+
     private AclEntryImpl (AclEntryImpl i) throws UnknownHostException {
 	setPrincipal(i.getPrincipal());
 	permList = new Vector();
 	commList = new Vector();
-	
+
 	for (Enumeration en = i.communities(); en.hasMoreElements();){
 	    addCommunity((String)en.nextElement());
 	}
-	
+
 	for (Enumeration en = i.permissions(); en.hasMoreElements();){
-	    addPermission((java.security.acl.Permission)en.nextElement());
+	    addPermission((com.sun.jdmk.security.acl.Permission)en.nextElement());
 	}
 	if (i.isNegative()) setNegativePermissions();
     }
-    
+
     /**
      * Constructs an empty ACL entry.
      */
@@ -99,7 +99,7 @@ class AclEntryImpl implements AclEntry, Serializable {
 	permList = new Vector();
 	commList = new Vector();
     }
-  
+
     /**
      * Constructs an ACL entry with a specified principal.
      *
@@ -110,7 +110,7 @@ class AclEntryImpl implements AclEntry, Serializable {
 	permList = new Vector();
 	commList = new Vector();
     }
-  
+
     /**
      * Clones this ACL entry.
      *
@@ -125,10 +125,10 @@ class AclEntryImpl implements AclEntry, Serializable {
 	}
 	return (Object) i;
     }
-  
+
     /**
-     * Returns true if this is a negative ACL entry (one denying the 
-     * associated principal the set of permissions in the entry), false 
+     * Returns true if this is a negative ACL entry (one denying the
+     * associated principal the set of permissions in the entry), false
      * otherwise.
      *
      * @return true if this is a negative ACL entry, false if it's not.
@@ -136,109 +136,109 @@ class AclEntryImpl implements AclEntry, Serializable {
     public boolean isNegative(){
 	return neg;
     }
-  
+
     /**
-     * Adds the specified permission to this ACL entry. Note: An entry can 
+     * Adds the specified permission to this ACL entry. Note: An entry can
      * have multiple permissions.
      *
      * @param perm the permission to be associated with the principal in this
      *        entry
      * @return true if the permission is removed, false if the permission was
-     *         not part of this entry's permission set. 
+     *         not part of this entry's permission set.
      *
      */
-    public boolean addPermission(java.security.acl.Permission perm){
+    public boolean addPermission(com.sun.jdmk.security.acl.Permission perm){
 	if (permList.contains(perm)) return false;
 	permList.addElement(perm);
 	return true;
     }
-  
+
     /**
      * Removes the specified permission from this ACL entry.
      *
-     * @param perm the permission to be removed from this entry. 
-     * @return true if the permission is removed, false if the permission 
-     *  was not part of this entry's permission set. 
+     * @param perm the permission to be removed from this entry.
+     * @return true if the permission is removed, false if the permission
+     *  was not part of this entry's permission set.
      */
-    public boolean removePermission(java.security.acl.Permission perm){
+    public boolean removePermission(com.sun.jdmk.security.acl.Permission perm){
 	if (!permList.contains(perm)) return false;
 	permList.removeElement(perm);
 	return true;
     }
-  
+
     /**
-     * Checks if the specified permission is part of the permission set in 
-     * this entry. 
+     * Checks if the specified permission is part of the permission set in
+     * this entry.
      *
      * @param perm the permission to be checked for.
-     * @return true if the permission is part of the permission set in this 
-     *    entry, false otherwise. 
+     * @return true if the permission is part of the permission set in this
+     *    entry, false otherwise.
      */
-  
-    public boolean checkPermission(java.security.acl.Permission perm){
+
+    public boolean checkPermission(com.sun.jdmk.security.acl.Permission perm){
 	return (permList.contains(perm));
     }
-  
+
     /**
      * Returns an enumeration of the permissions in this ACL entry.
      *
-     * @return an enumeration of the permissions in this ACL entry. 
+     * @return an enumeration of the permissions in this ACL entry.
      */
     public Enumeration permissions(){
 	return permList.elements();
     }
-  
+
     /**
-     * Sets this ACL entry to be a negative one. That is, the associated 
-     * principal (e.g., a user or a group) will be denied the permission set 
-     * specified in the entry. Note: ACL entries are by default positive. 
+     * Sets this ACL entry to be a negative one. That is, the associated
+     * principal (e.g., a user or a group) will be denied the permission set
+     * specified in the entry. Note: ACL entries are by default positive.
      * An entry becomes a negative entry only if this setNegativePermissions
-     * method is called on it. 
+     * method is called on it.
      *
      * Not Implemented.
      */
     public void setNegativePermissions(){
 	neg = true;
     }
-  
+
     /**
-     * Returns the principal for which permissions are granted or denied by 
+     * Returns the principal for which permissions are granted or denied by
      * this ACL
      * entry. Returns null if there is no principal set for this entry yet.
      *
-     * @return the principal associated with this entry. 
+     * @return the principal associated with this entry.
      */
     public Principal getPrincipal(){
 	return princ;
     }
-  
+
     /**
-     * Specifies the principal for which permissions are granted or denied 
+     * Specifies the principal for which permissions are granted or denied
      * by this ACL
-     * entry. If a principal was already set for this ACL entry, false is 
+     * entry. If a principal was already set for this ACL entry, false is
      * returned,
-     * otherwise true is returned. 
+     * otherwise true is returned.
      *
      * @param p the principal to be set for this entry.
-     * @return true if the principal is set, false if there was already a 
-     * principal set for this entry. 
+     * @return true if the principal is set, false if there was already a
+     * principal set for this entry.
      */
     public boolean setPrincipal(Principal p) {
-	if (princ != null ) 
+	if (princ != null )
 	    return false;
 	princ = p;
 	return true;
     }
-  
+
     /**
-     * Returns a string representation of the contents of this ACL entry. 
+     * Returns a string representation of the contents of this ACL entry.
      *
-     * @return a string representation of the contents. 
+     * @return a string representation of the contents.
      */
     public String toString(){
 	return "AclEntry:"+princ.toString();
     }
-  
+
     /**
      * Returns an enumeration of the communities in this ACL entry.
      *
@@ -247,58 +247,49 @@ class AclEntryImpl implements AclEntry, Serializable {
     public Enumeration communities(){
 	return commList.elements();
     }
-  
+
     /**
-     * Adds the specified community to this ACL entry. Note: An entry can 
+     * Adds the specified community to this ACL entry. Note: An entry can
      * have multiple communities.
      *
      * @param comm the community to be associated with the principal in this
-     *        entry. 
-     * @return true if the community was added, false if the community was 
-     *        already part of this entry's community set. 
+     *        entry.
+     * @return true if the community was added, false if the community was
+     *        already part of this entry's community set.
      */
     public boolean addCommunity(String comm){
 	if (commList.contains(comm)) return false;
 	commList.addElement(comm);
 	return true;
     }
-  
+
     /**
-     * Removes the specified community from this ACL entry. 
+     * Removes the specified community from this ACL entry.
      *
-     * @param comm the community  to be removed from this entry. 
+     * @param comm the community  to be removed from this entry.
      * @return true if the community is removed, false if the community was not
-     *         part of this entry's community set. 
+     *         part of this entry's community set.
      */
     public boolean removeCommunity(String comm){
 	if (!commList.contains(comm)) return false;
 	commList.removeElement(comm);
 	return true;
     }
-  
+
     /**
-     * Checks if the specified community is part of the community set in 
-     * this entry. 
+     * Checks if the specified community is part of the community set in
+     * this entry.
      *
-     * @param comm the community to be checked for. 
-     * @return true if the community is part of the community set in this 
-     *         entry, false otherwise. 
+     * @param comm the community to be checked for.
+     * @return true if the community is part of the community set in this
+     *         entry, false otherwise.
      */
     public boolean checkCommunity(String comm){
 	return (commList.contains(comm));
     }
-    
+
     private Principal princ = null;
     private boolean neg     = false;
     private Vector permList = null;
     private Vector commList = null;
 }
-
-
-
-
-
-
-
-
-

--- a/jdmkrt/snmp_manager/src/main/java/com/sun/management/snmp/IPAcl/AclImpl.java
+++ b/jdmkrt/snmp_manager/src/main/java/com/sun/management/snmp/IPAcl/AclImpl.java
@@ -4,19 +4,19 @@
  * @(#)version   4.14
  * @(#)date      07/10/01
  *
- * 
+ *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
- * 
+ *
  * Copyright (c) 2007 Sun Microsystems, Inc. All Rights Reserved.
- * 
+ *
  * The contents of this file are subject to the terms of either the GNU General
  * Public License Version 2 only ("GPL") or the Common Development and
  * Distribution License("CDDL")(collectively, the "License"). You may not use
  * this file except in compliance with the License. You can obtain a copy of the
- * License at http://opendmk.dev.java.net/legal_notices/licenses.txt or in the 
- * LEGAL_NOTICES folder that accompanied this code. See the License for the 
+ * License at http://opendmk.dev.java.net/legal_notices/licenses.txt or in the
+ * LEGAL_NOTICES folder that accompanied this code. See the License for the
  * specific language governing permissions and limitations under the License.
- * 
+ *
  * When distributing the software, include this License Header Notice in each
  * file and include the License file found at
  *     http://opendmk.dev.java.net/legal_notices/licenses.txt
@@ -24,27 +24,27 @@
  * Sun designates this particular file as subject to the "Classpath" exception
  * as provided by Sun in the GPL Version 2 section of the License file that
  * accompanied this code.
- * 
+ *
  * If applicable, add the following below the License Header, with the fields
  * enclosed by brackets [] replaced by your own identifying information:
- * 
+ *
  *       "Portions Copyrighted [year] [name of copyright owner]"
- * 
+ *
  * Contributor(s):
- * 
+ *
  * If you wish your version of this file to be governed by only the CDDL or
  * only the GPL Version 2, indicate your decision by adding
- * 
+ *
  *       "[Contributor] elects to include this software in this distribution
  *        under the [CDDL or GPL Version 2] license."
- * 
+ *
  * If you don't indicate a single choice of license, a recipient has the option
  * to distribute your version of this file under either the CDDL or the GPL
  * Version 2, or to extend the choice of license to its licensees as provided
  * above. However, if you add GPL Version 2 code and therefore, elected the
  * GPL Version 2 license, then the option applies only if the new code is made
  * subject to such option by the copyright holder.
- * 
+ *
  *
  */
 
@@ -54,9 +54,9 @@ package com.sun.management.snmp.IPAcl;
 
 
 import java.security.Principal;
-import java.security.acl.Acl; 
-import java.security.acl.AclEntry; 
-import java.security.acl.NotOwnerException; 
+import com.sun.jdmk.security.acl.Acl;
+import com.sun.jdmk.security.acl.AclEntry;
+import com.sun.jdmk.security.acl.NotOwnerException;
 
 import java.io.Serializable;
 import java.util.Vector;
@@ -64,19 +64,19 @@ import java.util.Enumeration;
 
 
 /**
- * Represent an Access Control List (ACL) which is used to guard access to 
+ * Represent an Access Control List (ACL) which is used to guard access to
  * snmp adaptor.
  * <P>
- * It is a data structure with multiple ACL entries. Each ACL entry, of 
- * interface type AclEntry, contains a set of permissions and a set of 
- * communities associated with a particular principal. (A principal 
+ * It is a data structure with multiple ACL entries. Each ACL entry, of
+ * interface type AclEntry, contains a set of permissions and a set of
+ * communities associated with a particular principal. (A principal
  * represents an entity such as a host or a group of host).
- * Additionally, each ACL entry is specified as being either positive or 
+ * Additionally, each ACL entry is specified as being either positive or
  * negative.
  * If positive, the permissions are to be granted to the associated principal.
  * If negative, the permissions are to be denied.
  *
- * @see java.security.acl.Acl
+ * @see com.sun.jdmk.security.acl.Acl
  *
  * @since Java DMK 5.1
  */
@@ -85,7 +85,7 @@ class AclImpl extends OwnerImpl implements Acl, Serializable {
     private static final long serialVersionUID = 8614545947280796145L;
     private Vector entryList = null;
     private String aclName = null;
-  
+
     /**
      * Constructs the ACL with a specified owner
      *
@@ -97,90 +97,90 @@ class AclImpl extends OwnerImpl implements Acl, Serializable {
 	entryList = new Vector();
 	aclName = name;
     }
-  
+
     /**
      * Sets the name of this ACL.
      *
      * @param caller the principal invoking this method. It must be an owner
      *        of this ACL.
-     * @param name the name to be given to this ACL. 
+     * @param name the name to be given to this ACL.
      *
      * @exception NotOwnerException if the caller principal is not an owner
-     *            of this ACL. 
+     *            of this ACL.
      * @see java.security.Principal
      */
     public void setName(Principal caller, String name)
 	throws NotOwnerException {
 	if (!isOwner(caller))
-	    throw new NotOwnerException();	
+	    throw new NotOwnerException();
 	aclName = name;
     }
-  
+
     /**
-     * Returns the name of this ACL. 
+     * Returns the name of this ACL.
      *
-     * @return the name of this ACL. 
+     * @return the name of this ACL.
      */
     public String getName(){
 	return aclName;
     }
-  
+
     /**
-     * Adds an ACL entry to this ACL. An entry associates a principal (e.g., 
-     * an individual or a group) with a set of permissions. Each principal 
+     * Adds an ACL entry to this ACL. An entry associates a principal (e.g.,
+     * an individual or a group) with a set of permissions. Each principal
      * can have at most one positive ACL entry
-     * (specifying permissions to be granted to the principal) and one 
+     * (specifying permissions to be granted to the principal) and one
      * negative ACL entry (specifying permissions to be denied). If there is
-     * already an ACL entry of the same type (negative or positive) already 
-     * in the ACL, false is returned. 
+     * already an ACL entry of the same type (negative or positive) already
+     * in the ACL, false is returned.
      *
-     * @param caller the principal invoking this method. It must be an owner 
-     *        of this ACL. 
-     * @param entry the ACL entry to be added to this ACL. 
-     * @return true on success, false if an entry of the same type (positive 
-     *    or negative) for the same principal is already present in this ACL. 
+     * @param caller the principal invoking this method. It must be an owner
+     *        of this ACL.
+     * @param entry the ACL entry to be added to this ACL.
+     * @return true on success, false if an entry of the same type (positive
+     *    or negative) for the same principal is already present in this ACL.
      * @exception NotOwnerException if the caller principal is not an owner
-     *    of this ACL. 
+     *    of this ACL.
      * @see java.security.Principal
      */
     public boolean addEntry(Principal caller, AclEntry entry)
 	throws NotOwnerException {
-	if (!isOwner(caller)) 
+	if (!isOwner(caller))
 	    throw new NotOwnerException();
-	
+
 	if (entryList.contains(entry))
 	    return false;
 	entryList.addElement(entry);
 	return true;
     }
-  
+
     /**
-     * Removes an ACL entry from this ACL. 
+     * Removes an ACL entry from this ACL.
      *
-     * @param caller the principal invoking this method. It must be an owner 
-     *        of this ACL. 
-     * @param entry the ACL entry to be removed from this ACL. 
-     * @return true on success, false if the entry is not part of this ACL. 
-     * @exception NotOwnerException if the caller principal is not an owner 
-     *       of this Acl. 
+     * @param caller the principal invoking this method. It must be an owner
+     *        of this ACL.
+     * @param entry the ACL entry to be removed from this ACL.
+     * @return true on success, false if the entry is not part of this ACL.
+     * @exception NotOwnerException if the caller principal is not an owner
+     *       of this Acl.
      * @see java.security.Principal
-     * @see java.security.acl.AclEntry
+     * @see com.sun.jdmk.security.acl.AclEntry
      */
     public boolean removeEntry(Principal caller, AclEntry entry)
 	throws NotOwnerException {
 	if (!isOwner(caller))
 	    throw new NotOwnerException();
-	
+
 	return (entryList.removeElement(entry));
     }
-    
+
     /**
      * Removes all ACL entries from this ACL.
      *
      * @param caller the principal invoking this method. It must be an owner
-     *        of this ACL. 
+     *        of this ACL.
      * @exception NotOwnerException if the caller principal is not an owner
-     *        of this Acl. 
+     *        of this Acl.
      * @see java.security.Principal
      */
     public void removeAll(Principal caller)
@@ -189,21 +189,21 @@ class AclImpl extends OwnerImpl implements Acl, Serializable {
 	    throw new NotOwnerException();
 	entryList.removeAllElements();
     }
-  
+
     /**
-     * Returns an enumeration for the set of allowed permissions for the 
+     * Returns an enumeration for the set of allowed permissions for the
      * specified principal (representing an entity such as an individual or a
      * group). This set of allowed permissions is calculated as follows:
      * <UL>
-     * <LI>If there is no entry in this Access Control List for the specified 
+     * <LI>If there is no entry in this Access Control List for the specified
      *    principal, an empty permission set is returned.</LI>
-     * <LI>Otherwise, the principal's group permission sets are determined. 
-     *    (A principal can belong to one or more groups, where a group is a 
+     * <LI>Otherwise, the principal's group permission sets are determined.
+     *    (A principal can belong to one or more groups, where a group is a
      *    group of principals, represented by the Group interface.)</LI>
      * </UL>
-     * @param user the principal whose permission set is to be returned. 
-     * @return the permission set specifying the permissions the principal 
-     *         is allowed. 
+     * @param user the principal whose permission set is to be returned.
+     * @return the permission set specifying the permissions the principal
+     *         is allowed.
      * @see java.security.Principal
      */
     public Enumeration getPermissions(Principal user){
@@ -215,35 +215,35 @@ class AclImpl extends OwnerImpl implements Acl, Serializable {
 	return java.util.Collections.
 	    enumeration(java.util.Collections.EMPTY_LIST);
     }
-  
+
     /**
      * Returns an enumeration of the entries in this ACL. Each element in the
-     * enumeration is of type AclEntry. 
+     * enumeration is of type AclEntry.
      *
-     * @return an enumeration of the entries in this ACL. 
+     * @return an enumeration of the entries in this ACL.
      */
     public Enumeration entries(){
 	return entryList.elements();
     }
-  
+
     /**
-     * Checks whether or not the specified principal has the specified 
+     * Checks whether or not the specified principal has the specified
      * permission. If it does, true is returned, otherwise false is returned.
      * More specifically, this method checks whether the passed permission is
-     * a member of the allowed permission set of the specified principal. The 
+     * a member of the allowed permission set of the specified principal. The
      * allowed permission set is determined by the same algorithm as is used
-     * by the getPermissions method. 
+     * by the getPermissions method.
      *
-     * @param user the principal, assumed to be a valid authenticated 
-     *        Principal. 
-     * @param perm the permission to be checked for. 
-     * @return true if the principal has the specified permission, false 
-     *        otherwise. 
+     * @param user the principal, assumed to be a valid authenticated
+     *        Principal.
+     * @param perm the permission to be checked for.
+     * @return true if the principal has the specified permission, false
+     *        otherwise.
      * @see java.security.Principal
      * @see java.security.Permission
      */
-    public boolean checkPermission(Principal user, 
-				   java.security.acl.Permission perm) {
+    public boolean checkPermission(Principal user,
+				   com.sun.jdmk.security.acl.Permission perm) {
 	for (Enumeration e = entryList.elements();e.hasMoreElements();){
 	    AclEntry ent = (AclEntry) e.nextElement();
 	    if (ent.getPrincipal().equals(user))
@@ -251,43 +251,43 @@ class AclImpl extends OwnerImpl implements Acl, Serializable {
 	}
 	return false;
     }
-  
+
     /**
-     * Checks whether or not the specified principal has the specified 
+     * Checks whether or not the specified principal has the specified
      * permission.
-     * If it does, true is returned, otherwise false is returned. 
-     * More specifically, this method checks whether the passed permission 
-     * is a member of the allowed permission set of the specified principal. 
+     * If it does, true is returned, otherwise false is returned.
+     * More specifically, this method checks whether the passed permission
+     * is a member of the allowed permission set of the specified principal.
      * The allowed permission set is determined by the same algorithm as is
-     * used by the getPermissions method. 
+     * used by the getPermissions method.
      *
-     * @param user the principal, assumed to be a valid authenticated 
-     *        Principal. 
+     * @param user the principal, assumed to be a valid authenticated
+     *        Principal.
      * @param community the community name associated with the principal.
-     * @param perm the permission to be checked for. 
-     * @return true if the principal has the specified permission, false 
-     *      otherwise. 
+     * @param perm the permission to be checked for.
+     * @return true if the principal has the specified permission, false
+     *      otherwise.
      * @see java.security.Principal
      * @see java.security.Permission
      */
-    public boolean checkPermission(Principal user, String community, 
-				   java.security.acl.Permission perm) {
+    public boolean checkPermission(Principal user, String community,
+				   com.sun.jdmk.security.acl.Permission perm) {
 	for (Enumeration e = entryList.elements();e.hasMoreElements();){
 	    AclEntryImpl ent = (AclEntryImpl) e.nextElement();
 	    if (ent.getPrincipal().equals(user))
-		if (ent.checkPermission(perm) && 
+		if (ent.checkPermission(perm) &&
 		    ent.checkCommunity(community)) return true;
 	}
 	return false;
     }
-  
+
     /**
-     * Checks whether or not the specified community string is defined. 
+     * Checks whether or not the specified community string is defined.
      *
      * @param community the community name associated with the principal.
      *
-     * @return true if the specified community string is defined, false 
-     *         otherwise. 
+     * @return true if the specified community string is defined, false
+     *         otherwise.
      * @see java.security.Principal
      * @see java.security.Permission
      */
@@ -298,19 +298,13 @@ class AclImpl extends OwnerImpl implements Acl, Serializable {
 	}
 	return false;
     }
-    
+
     /**
-     * Returns a string representation of the ACL contents. 
+     * Returns a string representation of the ACL contents.
      *
-     * @return a string representation of the ACL contents. 
+     * @return a string representation of the ACL contents.
      */
     public String toString(){
 	return ("AclImpl: "+ getName());
     }
 }
-
-
-
-
-
-

--- a/jdmkrt/snmp_manager/src/main/java/com/sun/management/snmp/IPAcl/GroupImpl.java
+++ b/jdmkrt/snmp_manager/src/main/java/com/sun/management/snmp/IPAcl/GroupImpl.java
@@ -4,19 +4,19 @@
  * @(#)version   4.12
  * @(#)date      07/10/01
  *
- * 
+ *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
- * 
+ *
  * Copyright (c) 2007 Sun Microsystems, Inc. All Rights Reserved.
- * 
+ *
  * The contents of this file are subject to the terms of either the GNU General
  * Public License Version 2 only ("GPL") or the Common Development and
  * Distribution License("CDDL")(collectively, the "License"). You may not use
  * this file except in compliance with the License. You can obtain a copy of the
- * License at http://opendmk.dev.java.net/legal_notices/licenses.txt or in the 
- * LEGAL_NOTICES folder that accompanied this code. See the License for the 
+ * License at http://opendmk.dev.java.net/legal_notices/licenses.txt or in the
+ * LEGAL_NOTICES folder that accompanied this code. See the License for the
  * specific language governing permissions and limitations under the License.
- * 
+ *
  * When distributing the software, include this License Header Notice in each
  * file and include the License file found at
  *     http://opendmk.dev.java.net/legal_notices/licenses.txt
@@ -24,27 +24,27 @@
  * Sun designates this particular file as subject to the "Classpath" exception
  * as provided by Sun in the GPL Version 2 section of the License file that
  * accompanied this code.
- * 
+ *
  * If applicable, add the following below the License Header, with the fields
  * enclosed by brackets [] replaced by your own identifying information:
- * 
+ *
  *       "Portions Copyrighted [year] [name of copyright owner]"
- * 
+ *
  * Contributor(s):
- * 
+ *
  * If you wish your version of this file to be governed by only the CDDL or
  * only the GPL Version 2, indicate your decision by adding
- * 
+ *
  *       "[Contributor] elects to include this software in this distribution
  *        under the [CDDL or GPL Version 2] license."
- * 
+ *
  * If you don't indicate a single choice of license, a recipient has the option
  * to distribute your version of this file under either the CDDL or the GPL
  * Version 2, or to extend the choice of license to its licensees as provided
  * above. However, if you add GPL Version 2 code and therefore, elected the
  * GPL Version 2 license, then the option applies only if the new code is made
  * subject to such option by the copyright holder.
- * 
+ *
  *
  */
 
@@ -59,15 +59,15 @@ import java.io.Serializable;
 import java.net.UnknownHostException;
 
 
-import java.security.Principal; 
-import java.security.acl.Group; 
+import java.security.Principal;
+import com.sun.jdmk.security.acl.Group;
 
 
 /**
- * This class is used to represent a subnet mask (a group of hosts matching 
+ * This class is used to represent a subnet mask (a group of hosts matching
  * the same IP mask).
- * 
- * @see java.security.acl.Group
+ *
+ * @see com.sun.jdmk.security.acl.Group
  * @see java.security.Principal
  *
  * @since Java DMK 5.1
@@ -75,14 +75,14 @@ import java.security.acl.Group;
 
 class GroupImpl extends PrincipalImpl implements Group, Serializable {
     private static final long serialVersionUID = -3849997127831107186L;
-  
+
     /**
      * Constructs an empty group.
      * @exception UnknownHostException Not implemented
      */
     public GroupImpl () throws UnknownHostException {
     }
-  
+
     /**
      * Constructs a group using the specified subnet mask.
      *
@@ -92,30 +92,30 @@ class GroupImpl extends PrincipalImpl implements Group, Serializable {
     public GroupImpl (String mask) throws UnknownHostException {
 	super(mask);
     }
-    
+
     /**
-     * Adds the specified member to the group. 
+     * Adds the specified member to the group.
      *
-     * @param p the principal to add to this group. 
-     * @return true if the member was successfully added, false if the 
-     *        principal was already a member. 
+     * @param p the principal to add to this group.
+     * @return true if the member was successfully added, false if the
+     *        principal was already a member.
      */
     public boolean addMember(Principal p) {
-	// we don't need to add members because the ip address is a 
-	// subnet mask 
-	return true;	
+	// we don't need to add members because the ip address is a
+	// subnet mask
+	return true;
     }
 
     public int hashCode() {
-	return super.hashCode();	
+	return super.hashCode();
     }
-  
+
     /**
      * Compares this group to the specified object. Returns true if the object
      * passed in matches the group represented.
      *
      * @param p the object to compare with.
-     * @return true if the object passed in matches the subnet mask, 
+     * @return true if the object passed in matches the subnet mask,
      *         false otherwise.
      */
     public boolean equals (Object p) {
@@ -126,19 +126,19 @@ class GroupImpl extends PrincipalImpl implements Group, Serializable {
 	    return false;
 	}
     }
-    
+
     /**
      * Returns true if the passed principal is a member of the group.
      *
      * @param p the principal whose membership is to be checked.
-     * @return true if the principal is a member of this group, 
-     *         false otherwise. 
+     * @return true if the principal is a member of this group,
+     *         false otherwise.
      */
     public boolean isMember(Principal p) {
 	if ((p.hashCode() & super.hashCode()) == p.hashCode()) return true;
 	else return false;
     }
-    
+
     /**
      * Returns an enumeration which contains the subnet mask.
      *
@@ -149,7 +149,7 @@ class GroupImpl extends PrincipalImpl implements Group, Serializable {
 	v.addElement(this);
 	return v.elements();
     }
-    
+
     /**
      * Removes the specified member from the group. (Not implemented)
      *
@@ -159,7 +159,7 @@ class GroupImpl extends PrincipalImpl implements Group, Serializable {
     public boolean removeMember(Principal p) {
 	return true;
     }
-  
+
     /**
      * Prints a string representation of this group.
      *
@@ -169,5 +169,3 @@ class GroupImpl extends PrincipalImpl implements Group, Serializable {
 	return ("GroupImpl :"+super.getAddress().toString());
     }
 }
-
-

--- a/jdmkrt/snmp_manager/src/main/java/com/sun/management/snmp/IPAcl/Host.java
+++ b/jdmkrt/snmp_manager/src/main/java/com/sun/management/snmp/IPAcl/Host.java
@@ -4,19 +4,19 @@
  * @(#)version   4.17
  * @(#)date      07/10/01
  *
- * 
+ *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
- * 
+ *
  * Copyright (c) 2007 Sun Microsystems, Inc. All Rights Reserved.
- * 
+ *
  * The contents of this file are subject to the terms of either the GNU General
  * Public License Version 2 only ("GPL") or the Common Development and
  * Distribution License("CDDL")(collectively, the "License"). You may not use
  * this file except in compliance with the License. You can obtain a copy of the
- * License at http://opendmk.dev.java.net/legal_notices/licenses.txt or in the 
- * LEGAL_NOTICES folder that accompanied this code. See the License for the 
+ * License at http://opendmk.dev.java.net/legal_notices/licenses.txt or in the
+ * LEGAL_NOTICES folder that accompanied this code. See the License for the
  * specific language governing permissions and limitations under the License.
- * 
+ *
  * When distributing the software, include this License Header Notice in each
  * file and include the License file found at
  *     http://opendmk.dev.java.net/legal_notices/licenses.txt
@@ -24,27 +24,27 @@
  * Sun designates this particular file as subject to the "Classpath" exception
  * as provided by Sun in the GPL Version 2 section of the License file that
  * accompanied this code.
- * 
+ *
  * If applicable, add the following below the License Header, with the fields
  * enclosed by brackets [] replaced by your own identifying information:
- * 
+ *
  *       "Portions Copyrighted [year] [name of copyright owner]"
- * 
+ *
  * Contributor(s):
- * 
+ *
  * If you wish your version of this file to be governed by only the CDDL or
  * only the GPL Version 2, indicate your decision by adding
- * 
+ *
  *       "[Contributor] elects to include this software in this distribution
  *        under the [CDDL or GPL Version 2] license."
- * 
+ *
  * If you don't indicate a single choice of license, a recipient has the option
  * to distribute your version of this file under either the CDDL or the GPL
  * Version 2, or to extend the choice of license to its licensees as provided
  * above. However, if you add GPL Version 2 code and therefore, elected the
  * GPL Version 2 license, then the option applies only if the new code is made
  * subject to such option by the copyright holder.
- * 
+ *
  *
  */
 
@@ -60,13 +60,13 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Hashtable;
 import java.util.Vector;
-import java.security.acl.NotOwnerException;
+import com.sun.jdmk.security.acl.NotOwnerException;
 
 // jdmk import
 //
 import com.sun.jdmk.internal.ClassLogger;
 
-  
+
 /**
  * The class defines an abstract representation of a host.
  *
@@ -74,7 +74,7 @@ import com.sun.jdmk.internal.ClassLogger;
  * @since Java DMK 5.1
  */
 abstract class Host extends SimpleNode implements Serializable {
-  
+
     public Host(int id) {
         super(id);
     }
@@ -82,10 +82,10 @@ abstract class Host extends SimpleNode implements Serializable {
     public Host(Parser p, int id) {
         super(p, id);
     }
-  
+
     protected abstract PrincipalImpl createAssociatedPrincipal()
         throws UnknownHostException;
-  
+
     protected abstract String getHname();
 
     public void buildAclEntries(PrincipalImpl owner, AclImpl acl) {
@@ -122,25 +122,25 @@ abstract class Host extends SimpleNode implements Serializable {
             return;
         }
     }
-    
+
     private void registerPermission(AclEntryImpl entry) {
-        JDMHost host= (JDMHost) jjtGetParent(); 
+        JDMHost host= (JDMHost) jjtGetParent();
         JDMManagers manager= (JDMManagers) host.jjtGetParent();
         JDMAclItem acl= (JDMAclItem) manager.jjtGetParent();
         JDMAccess access= (JDMAccess) acl.getAccess();
         access.putPermission(entry);
         JDMCommunities comm= (JDMCommunities) acl.getCommunities();
         comm.buildCommunities(entry);
-    } 
+    }
 
     public void buildTrapEntries(Hashtable dest) {
-        
-        JDMHostTrap host= (JDMHostTrap) jjtGetParent(); 
+
+        JDMHostTrap host= (JDMHostTrap) jjtGetParent();
         JDMTrapInterestedHost hosts= (JDMTrapInterestedHost) host.jjtGetParent();
         JDMTrapItem trap = (JDMTrapItem) hosts.jjtGetParent();
         JDMTrapCommunity community = (JDMTrapCommunity) trap.getCommunity();
         String comm = community.getCommunity();
-	
+
         InetAddress add = null;
         try {
             add = java.net.InetAddress.getByName(getHname());
@@ -150,7 +150,7 @@ abstract class Host extends SimpleNode implements Serializable {
             }
             return;
         }
-	
+
         Vector list = null;
         if (dest.containsKey(add)){
             list = (Vector) dest.get(add);
@@ -163,15 +163,15 @@ abstract class Host extends SimpleNode implements Serializable {
             dest.put(add,list);
         }
     }
-    
+
     public void buildInformEntries(Hashtable dest) {
-    
-        JDMHostInform host= (JDMHostInform) jjtGetParent(); 
+
+        JDMHostInform host= (JDMHostInform) jjtGetParent();
         JDMInformInterestedHost hosts= (JDMInformInterestedHost) host.jjtGetParent();
         JDMInformItem inform = (JDMInformItem) hosts.jjtGetParent();
         JDMInformCommunity community = (JDMInformCommunity) inform.getCommunity();
         String comm = community.getCommunity();
-	
+
         InetAddress add = null;
         try {
             add = java.net.InetAddress.getByName(getHname());
@@ -181,7 +181,7 @@ abstract class Host extends SimpleNode implements Serializable {
             }
             return;
         }
-	
+
         Vector list = null;
         if (dest.containsKey(add)){
             list = (Vector) dest.get(add);
@@ -194,12 +194,12 @@ abstract class Host extends SimpleNode implements Serializable {
             dest.put(add,list);
         }
     }
-    
+
     // Logging
     //--------
-    
-    private static final ClassLogger logger = 
+
+    private static final ClassLogger logger =
 	new ClassLogger(ClassLogger.LOGGER_SNMP,"Host");
-    
+
     String dbgTag = "Host";
 }

--- a/jdmkrt/snmp_manager/src/main/java/com/sun/management/snmp/IPAcl/JdmkAcl.java
+++ b/jdmkrt/snmp_manager/src/main/java/com/sun/management/snmp/IPAcl/JdmkAcl.java
@@ -4,19 +4,19 @@
  * @(#)version   4.41
  * @(#)date      07/10/01
  *
- * 
+ *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
- * 
+ *
  * Copyright (c) 2007 Sun Microsystems, Inc. All Rights Reserved.
- * 
+ *
  * The contents of this file are subject to the terms of either the GNU General
  * Public License Version 2 only ("GPL") or the Common Development and
  * Distribution License("CDDL")(collectively, the "License"). You may not use
  * this file except in compliance with the License. You can obtain a copy of the
- * License at http://opendmk.dev.java.net/legal_notices/licenses.txt or in the 
- * LEGAL_NOTICES folder that accompanied this code. See the License for the 
+ * License at http://opendmk.dev.java.net/legal_notices/licenses.txt or in the
+ * LEGAL_NOTICES folder that accompanied this code. See the License for the
  * specific language governing permissions and limitations under the License.
- * 
+ *
  * When distributing the software, include this License Header Notice in each
  * file and include the License file found at
  *     http://opendmk.dev.java.net/legal_notices/licenses.txt
@@ -24,27 +24,27 @@
  * Sun designates this particular file as subject to the "Classpath" exception
  * as provided by Sun in the GPL Version 2 section of the License file that
  * accompanied this code.
- * 
+ *
  * If applicable, add the following below the License Header, with the fields
  * enclosed by brackets [] replaced by your own identifying information:
- * 
+ *
  *       "Portions Copyrighted [year] [name of copyright owner]"
- * 
+ *
  * Contributor(s):
- * 
+ *
  * If you wish your version of this file to be governed by only the CDDL or
  * only the GPL Version 2, indicate your decision by adding
- * 
+ *
  *       "[Contributor] elects to include this software in this distribution
  *        under the [CDDL or GPL Version 2] license."
- * 
+ *
  * If you don't indicate a single choice of license, a recipient has the option
  * to distribute your version of this file under either the CDDL or the GPL
  * Version 2, or to extend the choice of license to its licensees as provided
  * above. However, if you add GPL Version 2 code and therefore, elected the
  * GPL Version 2 license, then the option applies only if the new code is made
  * subject to such option by the copyright holder.
- * 
+ *
  *
  */
 
@@ -65,8 +65,8 @@ import java.util.Hashtable;
 import java.util.Vector;
 import java.util.Enumeration;
 import java.util.HashSet;
-import java.security.acl.AclEntry; 
-import java.security.acl.NotOwnerException; 
+import com.sun.jdmk.security.acl.AclEntry;
+import com.sun.jdmk.security.acl.NotOwnerException;
 
 // jdmk import
 //
@@ -95,10 +95,10 @@ import com.sun.jdmk.defaults.Utils;
 
 public class JdmkAcl implements InetAddressAcl, Serializable {
     private static final long serialVersionUID = -1731776149894734768L;
-  
-    static final PermissionImpl READ  = new PermissionImpl("READ"); 
+
+    static final PermissionImpl READ  = new PermissionImpl("READ");
     static final PermissionImpl WRITE = new PermissionImpl("WRITE");
-  
+
     /**
      * Constructs the Java Dynamic Management(TM) Access Control List
      * based on IP addresses.  The ACL will take the given owner name.
@@ -112,10 +112,10 @@ public class JdmkAcl implements InetAddressAcl, Serializable {
      * @exception IllegalArgumentException If the ACL file doesn't exist.
      */
     public JdmkAcl(String name, String fileName)
-	throws UnknownHostException, IllegalArgumentException {   
+	throws UnknownHostException, IllegalArgumentException {
 	trapDestList= new Hashtable();
         informDestList= new Hashtable();
-        
+
         // PrincipalImpl() take the current host as entry
         owner = new PrincipalImpl();
         try {
@@ -130,12 +130,12 @@ public class JdmkAcl implements InetAddressAcl, Serializable {
 		      "the owner is built in this constructor");
             }
         }
-	
+
 	if(fileName == null)
 	    setDefautFileName();
 	else
 	    authorizedListFile = fileName;
-	
+
 	readAuthorisedListFile();
     }
 
@@ -146,27 +146,27 @@ public class JdmkAcl implements InetAddressAcl, Serializable {
      *
      * @param name The name of the ACL.
      *
-     * @exception UnknownHostException If the local host is unknown. 
-     * Thrown only if this class is instantiated internally by 
+     * @exception UnknownHostException If the local host is unknown.
+     * Thrown only if this class is instantiated internally by
      * <CODE> SnmpAdaptorServer </CODE> or <CODE> SnmpV3AdaptorServer </CODE>.
-     * 
+     *
      * @exception IllegalArgumentException If the ACL file doesn't exist.
      */
     public JdmkAcl(String name)
-	throws UnknownHostException, IllegalArgumentException {   
+	throws UnknownHostException, IllegalArgumentException {
         this(name, null);
     }
-  
+
     /**
      * Returns an enumeration of the entries in this ACL. Each element in the
-     * enumeration is of type <CODE>java.security.acl.AclEntry</CODE>.
+     * enumeration is of type <CODE>com.sun.jdmk.security.acl.AclEntry</CODE>.
      *
      * @return An enumeration of the entries in this ACL.
      */
     public synchronized Enumeration entries() {
         return acl.entries();
     }
-  
+
     /**
      * Returns an enumeration of community strings. Community strings are returned as String.
      * @return The enumeration of community strings.
@@ -176,7 +176,7 @@ public class JdmkAcl implements InetAddressAcl, Serializable {
 	Vector res = new Vector();
 	for (Enumeration e = acl.entries() ; e.hasMoreElements() ;) {
 	    AclEntryImpl entry = (AclEntryImpl) e.nextElement();
-	    for (Enumeration cs = entry.communities(); 
+	    for (Enumeration cs = entry.communities();
 		 cs.hasMoreElements() ;) {
 		set.add((String) cs.nextElement());
 	    }
@@ -196,7 +196,7 @@ public class JdmkAcl implements InetAddressAcl, Serializable {
     public synchronized String getName() {
         return acl.getName();
     }
-  
+
     /**
      * Returns the read permission instance used.
      *
@@ -205,7 +205,7 @@ public class JdmkAcl implements InetAddressAcl, Serializable {
     static public PermissionImpl getREAD() {
         return READ;
     }
-  
+
     /**
      * Returns the write permission instance used.
      *
@@ -214,7 +214,7 @@ public class JdmkAcl implements InetAddressAcl, Serializable {
     static public PermissionImpl getWRITE() {
         return WRITE;
     }
-  
+
     /**
      * Sets the full path of the file containing the ACL information.
      * Setting a file makes the previous loaded ACL configuration to be cleared.
@@ -225,12 +225,12 @@ public class JdmkAcl implements InetAddressAcl, Serializable {
      * @exception NotOwnerException This exception is never thrown.
      * @exception UnknownHostException If IP addresses for hosts contained in the ACL file couldn't be found.
      */
-    public synchronized void setAuthorizedListFile(String filename) 
-	throws IllegalArgumentException, 
+    public synchronized void setAuthorizedListFile(String filename)
+	throws IllegalArgumentException,
 	       NotOwnerException, UnknownHostException {
 	if(filename == null)
 	    throw new IllegalArgumentException("The specified file is null");
-	
+
 	File file = new File(filename);
 	if (!file.isFile() ) {
 	    if (logger.finestOn()) {
@@ -245,14 +245,14 @@ public class JdmkAcl implements InetAddressAcl, Serializable {
 
 	rereadTheFile();
     }
-  
+
     /**
      * Resets this ACL to the values contained in the configuration file.
      *
      * @exception NotOwnerException If the principal attempting the reset is not an owner of this ACL.
      * @exception UnknownHostException If IP addresses for hosts contained in the ACL file couldn't be found.
      */
-    public synchronized void rereadTheFile() 
+    public synchronized void rereadTheFile()
 	throws NotOwnerException, UnknownHostException {
         alwaysAuthorized = false;
         acl.removeAll(owner);
@@ -260,11 +260,11 @@ public class JdmkAcl implements InetAddressAcl, Serializable {
         informDestList.clear();
         AclEntry ownEntry = new AclEntryImpl(owner);
         ownEntry.addPermission(READ);
-        ownEntry.addPermission(WRITE);  
+        ownEntry.addPermission(WRITE);
         acl.addEntry(owner,ownEntry);
         readAuthorisedListFile();
     }
-  
+
     /**
      * Returns the full path of the file used to get ACL information.
      *
@@ -273,7 +273,7 @@ public class JdmkAcl implements InetAddressAcl, Serializable {
     public synchronized String getAuthorizedListFile() {
         return authorizedListFile;
     }
-  
+
     /**
      * Checks whether or not the specified host has <CODE>READ</CODE> access.
      *
@@ -286,7 +286,7 @@ public class JdmkAcl implements InetAddressAcl, Serializable {
         PrincipalImpl p = new PrincipalImpl(address);
         return acl.checkPermission(p, READ);
     }
-  
+
     /**
      * Checks whether or not the specified host and community have <CODE>READ</CODE> access.
      *
@@ -295,13 +295,13 @@ public class JdmkAcl implements InetAddressAcl, Serializable {
      *
      * @return <CODE>true</CODE> if the pair (host, community) has read permission, <CODE>false</CODE> otherwise.
      */
-    public synchronized boolean checkReadPermission(InetAddress address, 
+    public synchronized boolean checkReadPermission(InetAddress address,
 						    String community) {
         if (alwaysAuthorized) return ( true );
         PrincipalImpl p = new PrincipalImpl(address);
         return acl.checkPermission(p, community, READ);
     }
-  
+
     /**
      * Checks whether or not a community string is defined.
      *
@@ -312,7 +312,7 @@ public class JdmkAcl implements InetAddressAcl, Serializable {
     public synchronized boolean checkCommunity(String community) {
         return acl.checkCommunity(community);
     }
-  
+
     /**
      * Checks whether or not the specified host has <CODE>WRITE</CODE> access.
      *
@@ -324,7 +324,7 @@ public class JdmkAcl implements InetAddressAcl, Serializable {
         if (alwaysAuthorized) return ( true );
         PrincipalImpl p = new PrincipalImpl(address);
         return acl.checkPermission(p, WRITE);
-    } 
+    }
 
     /**
      * Checks whether or not the specified host and community have <CODE>WRITE</CODE> access.
@@ -334,13 +334,13 @@ public class JdmkAcl implements InetAddressAcl, Serializable {
      *
      * @return <CODE>true</CODE> if the pair (host, community) has write permission, <CODE>false</CODE> otherwise.
      */
-    public synchronized boolean checkWritePermission(InetAddress address, 
+    public synchronized boolean checkWritePermission(InetAddress address,
 						     String community) {
         if (alwaysAuthorized) return ( true );
         PrincipalImpl p = new PrincipalImpl(address);
         return acl.checkPermission(p, community, WRITE);
-    } 
-  
+    }
+
     /**
      * Returns an enumeration of trap destinations.
      *
@@ -349,7 +349,7 @@ public class JdmkAcl implements InetAddressAcl, Serializable {
     public synchronized Enumeration getTrapDestinations() {
         return trapDestList.keys();
     }
-  
+
     /**
      * Returns an enumeration of trap communities for a given host.
      *
@@ -370,9 +370,9 @@ public class JdmkAcl implements InetAddressAcl, Serializable {
                 logger.finer("getTrapCommunities", "["+i.toString()+"] is not in list");
             }
             return list.elements();
-        } 
+        }
     }
-  
+
     /**
      * Returns an enumeration of inform destinations.
      *
@@ -381,7 +381,7 @@ public class JdmkAcl implements InetAddressAcl, Serializable {
     public synchronized Enumeration getInformDestinations() {
         return informDestList.keys();
     }
-  
+
     /**
      * Returns an enumeration of inform communities for a given host.
      *
@@ -402,11 +402,11 @@ public class JdmkAcl implements InetAddressAcl, Serializable {
                 logger.finer("getInformCommunities", "["+i.toString()+"] is not in list");
             }
             return list.elements();
-        } 
+        }
     }
-  
+
     /**
-     * Fix for 6305089 and 6238234. Non readable file make ACL to throw 
+     * Fix for 6305089 and 6238234. Non readable file make ACL to throw
      * an exception.
      */
     private static void checkCanRead(String f) throws IllegalArgumentException {
@@ -415,7 +415,7 @@ public class JdmkAcl implements InetAddressAcl, Serializable {
             throw new IllegalArgumentException("IP ACL file is not " +
                     "readable.");
     }
-    
+
     /**
      * Converts the input configuration file into ACL.
      */
@@ -430,7 +430,7 @@ public class JdmkAcl implements InetAddressAcl, Serializable {
             alwaysAuthorized = true ;
         } else {
             // Read the file content
-            Parser parser = null;  
+            Parser parser = null;
             try {
                 checkCanRead(getAuthorizedListFile());
                 parser= new Parser(new FileInputStream(getAuthorizedListFile()));
@@ -441,7 +441,7 @@ public class JdmkAcl implements InetAddressAcl, Serializable {
                 alwaysAuthorized = true ;
                 return;
             }
-          
+
             try {
                 JDMSecurityDefs n = parser.SecurityDefs();
                 n.buildAclEntries(owner, acl);
@@ -449,31 +449,31 @@ public class JdmkAcl implements InetAddressAcl, Serializable {
                 n.buildInformEntries(informDestList);
             } catch (ParseException e) {
                 if (logger.finestOn()) {
-                    logger.finest("readAuthorisedListFile", 
+                    logger.finest("readAuthorisedListFile",
 				  "Parsing exception " + e);
                 }
-		final IllegalArgumentException iae = 
+		final IllegalArgumentException iae =
 		    new IllegalArgumentException("Syntax error: " + e);
 		Utils.initCause(iae,e);
 		throw iae;
             } catch (Error err) {
                 if (logger.finestOn()) {
-                    logger.finest("readAuthorisedListFile", 
+                    logger.finest("readAuthorisedListFile",
 				  "Error exception " + err);
                 }
-		final IllegalArgumentException iae = 
+		final IllegalArgumentException iae =
 		    new IllegalArgumentException("Error: " + err);
 		Utils.initCause(iae,err);
 		throw iae;
             }
-          
+
             for(Enumeration e = acl.entries(); e.hasMoreElements();) {
                 AclEntryImpl aa = (AclEntryImpl) e.nextElement();
                 if (logger.finerOn()) {
                     logger.finer("readAuthorisedListFile", "===> " + aa.getPrincipal().toString());
                 }
                 for (Enumeration eee = aa.permissions();eee.hasMoreElements();) {
-                    java.security.acl.Permission perm = (java.security.acl.Permission)eee.nextElement();
+                    com.sun.jdmk.security.acl.Permission perm = (com.sun.jdmk.security.acl.Permission)eee.nextElement();
                     if (logger.finerOn()) {
                         logger.finer("readAuthorisedListFile", "perm = " + perm);
                     }
@@ -481,23 +481,23 @@ public class JdmkAcl implements InetAddressAcl, Serializable {
             }
         }
     }
-  
+
     /**
      * Set the default full path for "jdmk.acl" input file.
      */
     private void setDefautFileName() throws IllegalArgumentException {
-	String aclFile = null;	
+	String aclFile = null;
 	File file = null;
-	
+
         if ((aclFile = (String) System.getProperty(JdmkProperties.ACL_FILE)) == null) {
             aclFile = DefaultPaths.getEtcDir("conf" + File.separator + "jdmk.acl");
 	    if (logger.finestOn())
-		logger.finest("setDefautFileName", 
+		logger.finest("setDefautFileName",
 		      "Default File name is : " + aclFile);
 	    file = new File(aclFile);
 	    if (file.isFile()) {
 		if (logger.finerOn()) {
-		    logger.finer("setDefautFileName", 
+		    logger.finer("setDefautFileName",
 			  "Default Ip ACL file found : " + aclFile);
 		}
 	    } else {
@@ -521,19 +521,19 @@ public class JdmkAcl implements InetAddressAcl, Serializable {
 	}
         authorizedListFile = aclFile;
     }
-  
-    
+
+
     // Logging
     //--------
-    
-    private static final ClassLogger logger = 
+
+    private static final ClassLogger logger =
 	new ClassLogger(ClassLogger.LOGGER_SNMP,"JdmkAcl");
-    
+
     String dbgTag = "JdmkAcl";
-    
+
     // PRIVATE VARIABLES
     //------------------
-    
+
     /**
      * Represents the Access Control List.
      */
@@ -555,6 +555,6 @@ public class JdmkAcl implements InetAddressAcl, Serializable {
      * Contains the hosts list for inform destination.
      */
     private Hashtable informDestList = null;
-    
+
     private PrincipalImpl owner = null;
 }

--- a/jdmkrt/snmp_manager/src/main/java/com/sun/management/snmp/IPAcl/NetMaskImpl.java
+++ b/jdmkrt/snmp_manager/src/main/java/com/sun/management/snmp/IPAcl/NetMaskImpl.java
@@ -4,19 +4,19 @@
  * @(#)version   1.11
  * @(#)date      07/10/01
  *
- * 
+ *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
- * 
+ *
  * Copyright (c) 2007 Sun Microsystems, Inc. All Rights Reserved.
- * 
+ *
  * The contents of this file are subject to the terms of either the GNU General
  * Public License Version 2 only ("GPL") or the Common Development and
  * Distribution License("CDDL")(collectively, the "License"). You may not use
  * this file except in compliance with the License. You can obtain a copy of the
- * License at http://opendmk.dev.java.net/legal_notices/licenses.txt or in the 
- * LEGAL_NOTICES folder that accompanied this code. See the License for the 
+ * License at http://opendmk.dev.java.net/legal_notices/licenses.txt or in the
+ * LEGAL_NOTICES folder that accompanied this code. See the License for the
  * specific language governing permissions and limitations under the License.
- * 
+ *
  * When distributing the software, include this License Header Notice in each
  * file and include the License file found at
  *     http://opendmk.dev.java.net/legal_notices/licenses.txt
@@ -24,27 +24,27 @@
  * Sun designates this particular file as subject to the "Classpath" exception
  * as provided by Sun in the GPL Version 2 section of the License file that
  * accompanied this code.
- * 
+ *
  * If applicable, add the following below the License Header, with the fields
  * enclosed by brackets [] replaced by your own identifying information:
- * 
+ *
  *       "Portions Copyrighted [year] [name of copyright owner]"
- * 
+ *
  * Contributor(s):
- * 
+ *
  * If you wish your version of this file to be governed by only the CDDL or
  * only the GPL Version 2, indicate your decision by adding
- * 
+ *
  *       "[Contributor] elects to include this software in this distribution
  *        under the [CDDL or GPL Version 2] license."
- * 
+ *
  * If you don't indicate a single choice of license, a recipient has the option
  * to distribute your version of this file under either the CDDL or the GPL
  * Version 2, or to extend the choice of license to its licensees as provided
  * above. However, if you add GPL Version 2 code and therefore, elected the
  * GPL Version 2 license, then the option applies only if the new code is made
  * subject to such option by the copyright holder.
- * 
+ *
  *
  */
 
@@ -58,16 +58,16 @@ import java.io.Serializable;
 import java.net.UnknownHostException;
 import java.net.InetAddress;
 
-import java.security.Principal; 
-import java.security.acl.Group; 
+import java.security.Principal;
+import com.sun.jdmk.security.acl.Group;
 
 import com.sun.jdmk.internal.ClassLogger;
 
 /**
- * This class is used to represent a subnet mask (a group of hosts matching 
+ * This class is used to represent a subnet mask (a group of hosts matching
  * the same IP mask).
- * 
- * @see java.security.acl.Group
+ *
+ * @see com.sun.jdmk.security.acl.Group
  * @see java.security.Principal
  *
  * @since Java DMK 5.1
@@ -83,7 +83,7 @@ class NetMaskImpl extends PrincipalImpl implements Group, Serializable {
      */
     public NetMaskImpl () throws UnknownHostException {
     }
-  
+
     private byte[] extractSubNet(byte[] b) {
 	int addrLength = b.length;
 	byte[] subnet = null;
@@ -95,7 +95,7 @@ class NetMaskImpl extends PrincipalImpl implements Group, Serializable {
 	    }
 	    logger.finest("extractSubNet", buff.toString());
 	}
-	
+
 	// 8 is a byte size. Common to any InetAddress (V4 or V6).
 	int fullyCoveredByte = prefix / 8;
 	if(fullyCoveredByte == addrLength) {
@@ -123,20 +123,20 @@ class NetMaskImpl extends PrincipalImpl implements Group, Serializable {
 	if(logger.finestOn()) {
 	    logger.finest("extractSubNet"," Partialy covered byte : " + toDeal);
 	}
-	
+
 	// 8 is a byte size. Common to any InetAddress (V4 or V6).
 	int nbbits = prefix % 8;
 	int subnetSize = 0;
-	
-	if(nbbits == 0) 
+
+	if(nbbits == 0)
 	subnetSize = partialyCoveredIndex;
 	else
 	subnetSize = partialyCoveredIndex + 1;
-	
+
 	if(logger.finestOn()) {
 	    logger.finest("extractSubNet"," Remains : " + nbbits);
 	}
-	
+
 	byte mask = 0;
 	for(int i = 0; i < nbbits; i++) {
 	    mask |= (1 << (7 - i));
@@ -144,9 +144,9 @@ class NetMaskImpl extends PrincipalImpl implements Group, Serializable {
 	if(logger.finestOn()) {
 	    logger.finest("extractSubNet","Mask value" + (int) (mask & 0xFF));
 	}
-	
+
 	byte maskedValue = (byte) ((int)toDeal & (int)mask);
-	
+
 	if(logger.finestOn()) {
 	    logger.finest("extractSubNet","Masked byte :"  + (int)(maskedValue &0xFF));
 	}
@@ -156,16 +156,16 @@ class NetMaskImpl extends PrincipalImpl implements Group, Serializable {
 	}
 	for(int i = 0; i < partialyCoveredIndex; i++) {
 	    subnet[i] = b[i];
-	    
+
 	    if(logger.finestOn()) {
 		logger.finest("extractSubNet",(int) (subnet[i] & 0xFF) +":");
 	    }
 	}
-	
+
 	if(nbbits != 0) {
 	    subnet[partialyCoveredIndex] = maskedValue;
 	    if(logger.finestOn()) {
-		logger.finest("extractSubNet"," Last subnet byte : " + 
+		logger.finest("extractSubNet"," Last subnet byte : " +
 		      (int) (subnet[partialyCoveredIndex] &0xFF));
 	    }
 	}
@@ -178,36 +178,36 @@ class NetMaskImpl extends PrincipalImpl implements Group, Serializable {
      *
      * @exception UnknownHostException if the subnet mask cann't be built.
      */
-    public NetMaskImpl (String hostname, int prefix) 
+    public NetMaskImpl (String hostname, int prefix)
 	throws UnknownHostException {
 	super(hostname);
 	this.prefix = prefix;
 	subnet = extractSubNet(getAddress().getAddress());
     }
-  
+
     /**
-     * Adds the specified member to the group. 
+     * Adds the specified member to the group.
      *
-     * @param p the principal to add to this group. 
-     * @return true if the member was successfully added, false if the 
-     *         principal was already a member. 
+     * @param p the principal to add to this group.
+     * @return true if the member was successfully added, false if the
+     *         principal was already a member.
      */
     public boolean addMember(Principal p) {
-	// we don't need to add members because the ip address is a 
-	// subnet mask 
-	return true;	
+	// we don't need to add members because the ip address is a
+	// subnet mask
+	return true;
     }
 
     public int hashCode() {
-	return super.hashCode();	
+	return super.hashCode();
     }
-  
+
     /**
      * Compares this group to the specified object. Returns true if the object
      * passed in matches the group represented.
      *
      * @param p the object to compare with.
-     * @return true if the object passed in matches the subnet mask, false 
+     * @return true if the object passed in matches the subnet mask, false
      *         otherwise.
      */
     public boolean equals (Object p) {
@@ -220,7 +220,7 @@ class NetMaskImpl extends PrincipalImpl implements Group, Serializable {
 	    byte[] recAddr = addr.getAddress();
 	    for(int i = 0; i < subnet.length; i++) {
 		if(logger.finestOn()) {
-		    logger.finest("equals","(recAddr[i]) :" + (recAddr[i] & 0xFF)); 
+		    logger.finest("equals","(recAddr[i]) :" + (recAddr[i] & 0xFF));
 		    logger.finest("equals","(recAddr[i] & subnet[i]) :" +
 			  ( (int) (recAddr[i] & (int)subnet[i]) &0xFF) +
 			  "subnet[i] :" + (int) (subnet[i] &0xFF));
@@ -244,14 +244,14 @@ class NetMaskImpl extends PrincipalImpl implements Group, Serializable {
      * Returns true if the passed principal is a member of the group.
      *
      * @param p the principal whose membership is to be checked.
-     * @return true if the principal is a member of this group, false 
-     *         otherwise. 
+     * @return true if the principal is a member of this group, false
+     *         otherwise.
      */
     public boolean isMember(Principal p) {
 	if ((p.hashCode() & super.hashCode()) == p.hashCode()) return true;
 	else return false;
     }
-  
+
     /**
      * Returns an enumeration which contains the subnet mask.
      *
@@ -262,7 +262,7 @@ class NetMaskImpl extends PrincipalImpl implements Group, Serializable {
 	v.addElement(this);
 	return v.elements();
     }
-  
+
     /**
      * Removes the specified member from the group. (Not implemented)
      *
@@ -272,7 +272,7 @@ class NetMaskImpl extends PrincipalImpl implements Group, Serializable {
     public boolean removeMember(Principal p) {
 	return true;
     }
-  
+
     /**
      * Prints a string representation of this group.
      *
@@ -284,10 +284,8 @@ class NetMaskImpl extends PrincipalImpl implements Group, Serializable {
 
     // Logging
     //--------
-    private static final ClassLogger logger = 
+    private static final ClassLogger logger =
 	new ClassLogger(ClassLogger.LOGGER_SNMP,"NetMaskImpl");
 
-    String dbgTag = "NetMaskImpl"; 
+    String dbgTag = "NetMaskImpl";
 }
-
-

--- a/jdmkrt/snmp_manager/src/main/java/com/sun/management/snmp/IPAcl/OwnerImpl.java
+++ b/jdmkrt/snmp_manager/src/main/java/com/sun/management/snmp/IPAcl/OwnerImpl.java
@@ -4,19 +4,19 @@
  * @(#)version   4.12
  * @(#)date      07/10/01
  *
- * 
+ *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
- * 
+ *
  * Copyright (c) 2007 Sun Microsystems, Inc. All Rights Reserved.
- * 
+ *
  * The contents of this file are subject to the terms of either the GNU General
  * Public License Version 2 only ("GPL") or the Common Development and
  * Distribution License("CDDL")(collectively, the "License"). You may not use
  * this file except in compliance with the License. You can obtain a copy of the
- * License at http://opendmk.dev.java.net/legal_notices/licenses.txt or in the 
- * LEGAL_NOTICES folder that accompanied this code. See the License for the 
+ * License at http://opendmk.dev.java.net/legal_notices/licenses.txt or in the
+ * LEGAL_NOTICES folder that accompanied this code. See the License for the
  * specific language governing permissions and limitations under the License.
- * 
+ *
  * When distributing the software, include this License Header Notice in each
  * file and include the License file found at
  *     http://opendmk.dev.java.net/legal_notices/licenses.txt
@@ -24,27 +24,27 @@
  * Sun designates this particular file as subject to the "Classpath" exception
  * as provided by Sun in the GPL Version 2 section of the License file that
  * accompanied this code.
- * 
+ *
  * If applicable, add the following below the License Header, with the fields
  * enclosed by brackets [] replaced by your own identifying information:
- * 
+ *
  *       "Portions Copyrighted [year] [name of copyright owner]"
- * 
+ *
  * Contributor(s):
- * 
+ *
  * If you wish your version of this file to be governed by only the CDDL or
  * only the GPL Version 2, indicate your decision by adding
- * 
+ *
  *       "[Contributor] elects to include this software in this distribution
  *        under the [CDDL or GPL Version 2] license."
- * 
+ *
  * If you don't indicate a single choice of license, a recipient has the option
  * to distribute your version of this file under either the CDDL or the GPL
  * Version 2, or to extend the choice of license to its licensees as provided
  * above. However, if you add GPL Version 2 code and therefore, elected the
  * GPL Version 2 license, then the option applies only if the new code is made
  * subject to such option by the copyright holder.
- * 
+ *
  *
  */
 
@@ -57,9 +57,9 @@ import java.util.Vector;
 import java.io.Serializable;
 
 import java.security.Principal;
-import java.security.acl.Owner; 
-import java.security.acl.LastOwnerException; 
-import java.security.acl.NotOwnerException; 
+import com.sun.jdmk.security.acl.Owner;
+import com.sun.jdmk.security.acl.LastOwnerException;
+import com.sun.jdmk.security.acl.NotOwnerException;
 
 
 /**
@@ -67,7 +67,7 @@ import java.security.acl.NotOwnerException;
  * The initial owner Principal should be specified as an
  * argument to the constructor of the class AclImpl.
  *
- * @see java.security.acl.Owner
+ * @see com.sun.jdmk.security.acl.Owner
  *
  * @since Java DMK 5.1
  */
@@ -75,16 +75,16 @@ import java.security.acl.NotOwnerException;
 class OwnerImpl implements Owner, Serializable {
     private static final long serialVersionUID = -3578834791769792453L;
     private Vector ownerList = null;
-  
+
     /**
      * Constructs an empty list of owner.
      */
     public OwnerImpl (){
 	ownerList = new Vector();
     }
-  
+
     /**
-     * Constructs a list of owner with the specified principal as first 
+     * Constructs a list of owner with the specified principal as first
      * element.
      *
      * @param owner the principal added to the owner list.
@@ -93,25 +93,25 @@ class OwnerImpl implements Owner, Serializable {
 	ownerList = new Vector();
 	ownerList.addElement(owner);
     }
-  
+
     /**
      * Adds an owner. Only owners can modify ACL contents. The caller principal
-     * must be an owner of the ACL in order to invoke this method. That is, 
+     * must be an owner of the ACL in order to invoke this method. That is,
      * only an owner can add another owner. The initial owner is configured at
      * ACL construction time.
      *
-     * @param caller the principal invoking this method. It must be an owner 
+     * @param caller the principal invoking this method. It must be an owner
      *        of the ACL.
      * @param owner the owner that should be added to the list of owners.
-     * @return true if successful, false if owner is already an owner. 
-     * @exception NotOwnerException if the caller principal is not an owner 
-     *        of the ACL. 
+     * @return true if successful, false if owner is already an owner.
+     * @exception NotOwnerException if the caller principal is not an owner
+     *        of the ACL.
      */
-    public boolean addOwner(Principal caller, Principal owner) 
+    public boolean addOwner(Principal caller, Principal owner)
 	throws NotOwnerException {
-	if (!ownerList.contains(caller)) 
+	if (!ownerList.contains(caller))
 	    throw new NotOwnerException();
-	
+
 	if (ownerList.contains(owner)) {
 	    return false;
 	} else {
@@ -119,20 +119,20 @@ class OwnerImpl implements Owner, Serializable {
 	    return true;
 	}
     }
-  
+
     /**
-     * Deletes an owner. If this is the last owner in the ACL, an exception 
+     * Deletes an owner. If this is the last owner in the ACL, an exception
      * is raised.
      *<P>
-     * The caller principal must be an owner of the ACL in order to invoke 
-     * this method. 
+     * The caller principal must be an owner of the ACL in order to invoke
+     * this method.
      *
-     * @param caller the principal invoking this method. It must be an owner 
-     *        of the ACL. 
-     * @param owner the owner to be removed from the list of owners. 
-     * @return true if successful, false if owner is already an owner. 
-     * @exception NotOwnerException if the caller principal is not an owner 
-     *        of the ACL. 
+     * @param caller the principal invoking this method. It must be an owner
+     *        of the ACL.
+     * @param owner the owner to be removed from the list of owners.
+     * @return true if successful, false if owner is already an owner.
+     * @exception NotOwnerException if the caller principal is not an owner
+     *        of the ACL.
      * @exception LastOwnerException if there is only one owner left, so that
      *        deleteOwner would leave the ACL owner-less.
      */
@@ -141,23 +141,23 @@ class OwnerImpl implements Owner, Serializable {
 
 	if (!ownerList.contains(caller))
 	    throw new NotOwnerException();
-	
+
 	if (!ownerList.contains(owner)){
 	    return false;
 	} else {
 	    if (ownerList.size() == 1)
 		throw new LastOwnerException();
-	    
+
 	    ownerList.removeElement(owner);
 	    return true;
 	}
     }
-    
+
     /**
      * Returns true if the given principal is an owner of the ACL.
      *
-     * @param owner the principal to be checked to determine whether or 
-     *        not it is an owner. 
+     * @param owner the principal to be checked to determine whether or
+     *        not it is an owner.
      * @return true if the given principal is an owner of the ACL.
      */
     public boolean isOwner(Principal owner){

--- a/jdmkrt/snmp_manager/src/main/java/com/sun/management/snmp/IPAcl/PermissionImpl.java
+++ b/jdmkrt/snmp_manager/src/main/java/com/sun/management/snmp/IPAcl/PermissionImpl.java
@@ -4,19 +4,19 @@
  * @(#)version   4.13
  * @(#)date      07/10/01
  *
- * 
+ *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
- * 
+ *
  * Copyright (c) 2007 Sun Microsystems, Inc. All Rights Reserved.
- * 
+ *
  * The contents of this file are subject to the terms of either the GNU General
  * Public License Version 2 only ("GPL") or the Common Development and
  * Distribution License("CDDL")(collectively, the "License"). You may not use
  * this file except in compliance with the License. You can obtain a copy of the
- * License at http://opendmk.dev.java.net/legal_notices/licenses.txt or in the 
- * LEGAL_NOTICES folder that accompanied this code. See the License for the 
+ * License at http://opendmk.dev.java.net/legal_notices/licenses.txt or in the
+ * LEGAL_NOTICES folder that accompanied this code. See the License for the
  * specific language governing permissions and limitations under the License.
- * 
+ *
  * When distributing the software, include this License Header Notice in each
  * file and include the License file found at
  *     http://opendmk.dev.java.net/legal_notices/licenses.txt
@@ -24,27 +24,27 @@
  * Sun designates this particular file as subject to the "Classpath" exception
  * as provided by Sun in the GPL Version 2 section of the License file that
  * accompanied this code.
- * 
+ *
  * If applicable, add the following below the License Header, with the fields
  * enclosed by brackets [] replaced by your own identifying information:
- * 
+ *
  *       "Portions Copyrighted [year] [name of copyright owner]"
- * 
+ *
  * Contributor(s):
- * 
+ *
  * If you wish your version of this file to be governed by only the CDDL or
  * only the GPL Version 2, indicate your decision by adding
- * 
+ *
  *       "[Contributor] elects to include this software in this distribution
  *        under the [CDDL or GPL Version 2] license."
- * 
+ *
  * If you don't indicate a single choice of license, a recipient has the option
  * to distribute your version of this file under either the CDDL or the GPL
  * Version 2, or to extend the choice of license to its licensees as provided
  * above. However, if you add GPL Version 2 code and therefore, elected the
  * GPL Version 2 license, then the option applies only if the new code is made
  * subject to such option by the copyright holder.
- * 
+ *
  *
  */
 
@@ -64,10 +64,10 @@ import java.io.Serializable;
  * @since Java DMK 5.1
  */
 
-class PermissionImpl implements java.security.acl.Permission, Serializable {
+class PermissionImpl implements com.sun.jdmk.security.acl.Permission, Serializable {
     private static final long serialVersionUID = 4852094599955129196L;
     private String perm = null;
-  
+
     /**
      * Constructs a permission.
      *
@@ -76,17 +76,17 @@ class PermissionImpl implements java.security.acl.Permission, Serializable {
     public PermissionImpl(String s) {
 	perm = s;
     }
-    
+
     public int hashCode() {
-	if (perm == null) return 0; 
+	if (perm == null) return 0;
 	return perm.hashCode();
     }
-  
+
     /**
-     * Returns true if the object passed matches the permission 
-     * represented in. 
+     * Returns true if the object passed matches the permission
+     * represented in.
      *
-     * @param p the Permission object to compare with. 
+     * @param p the Permission object to compare with.
      * @return true if the Permission objects are equal, false otherwise.
      */
     public boolean equals(Object p){
@@ -96,23 +96,22 @@ class PermissionImpl implements java.security.acl.Permission, Serializable {
 	    return false;
 	}
     }
-  
+
     /**
-     * Prints a string representation of this permission. 
+     * Prints a string representation of this permission.
      *
-     * @return a string representation of this permission. 
+     * @return a string representation of this permission.
      */
     public String toString(){
 	return perm.toString();
     }
-  
+
     /**
-     * Prints the permission. 
+     * Prints the permission.
      *
-     * @return a string representation of this permission. 
+     * @return a string representation of this permission.
      */
     public String getString(){
 	return perm;
     }
 }
-

--- a/jdmkrt/snmp_manager/src/main/java/com/sun/management/snmp/uacl/AclEntryImpl.java
+++ b/jdmkrt/snmp_manager/src/main/java/com/sun/management/snmp/uacl/AclEntryImpl.java
@@ -4,19 +4,19 @@
  * @(#)version   1.12
  * @(#)lastedit  07/03/08
  *
- * 
+ *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
- * 
+ *
  * Copyright (c) 2007 Sun Microsystems, Inc. All Rights Reserved.
- * 
+ *
  * The contents of this file are subject to the terms of either the GNU General
  * Public License Version 2 only ("GPL") or the Common Development and
  * Distribution License("CDDL")(collectively, the "License"). You may not use
  * this file except in compliance with the License. You can obtain a copy of the
- * License at http://opendmk.dev.java.net/legal_notices/licenses.txt or in the 
- * LEGAL_NOTICES folder that accompanied this code. See the License for the 
+ * License at http://opendmk.dev.java.net/legal_notices/licenses.txt or in the
+ * LEGAL_NOTICES folder that accompanied this code. See the License for the
  * specific language governing permissions and limitations under the License.
- * 
+ *
  * When distributing the software, include this License Header Notice in each
  * file and include the License file found at
  *     http://opendmk.dev.java.net/legal_notices/licenses.txt
@@ -24,27 +24,27 @@
  * Sun designates this particular file as subject to the "Classpath" exception
  * as provided by Sun in the GPL Version 2 section of the License file that
  * accompanied this code.
- * 
+ *
  * If applicable, add the following below the License Header, with the fields
  * enclosed by brackets [] replaced by your own identifying information:
- * 
+ *
  *       "Portions Copyrighted [year] [name of copyright owner]"
- * 
+ *
  * Contributor(s):
- * 
+ *
  * If you wish your version of this file to be governed by only the CDDL or
  * only the GPL Version 2, indicate your decision by adding
- * 
+ *
  *       "[Contributor] elects to include this software in this distribution
  *        under the [CDDL or GPL Version 2] license."
- * 
+ *
  * If you don't indicate a single choice of license, a recipient has the option
  * to distribute your version of this file under either the CDDL or the GPL
  * Version 2, or to extend the choice of license to its licensees as provided
  * above. However, if you add GPL Version 2 code and therefore, elected the
  * GPL Version 2 license, then the option applies only if the new code is made
  * subject to such option by the copyright holder.
- * 
+ *
  *
  */
 
@@ -58,8 +58,8 @@ import java.util.Enumeration;
 import java.io.Serializable;
 import java.net.UnknownHostException;
 
-import java.security.Principal; 
-import java.security.acl.AclEntry; 
+import java.security.Principal;
+import com.sun.jdmk.security.acl.AclEntry;
 
 
 /**
@@ -67,30 +67,30 @@ import java.security.acl.AclEntry;
  * This ACL entry object contains a permission associated with a particular principal.
  * (A principal represents an entity such as an individual machine or a group).
  *
- * @see java.security.acl.AclEntry
+ * @see com.sun.jdmk.security.acl.AclEntry
  *
  * @since Java DMK 5.1
  */
 
 class AclEntryImpl implements AclEntry, Serializable {
     private static final long serialVersionUID = -2167701162058432944L;
-  
+
   private AclEntryImpl (AclEntryImpl i) {
 	setPrincipal(i.getPrincipal());
 	setSecurityLevel(i.getSecurityLevel());
 	permList = new Vector();
 	commList = new Vector();
-	
+
 	for (Enumeration en = i.contextNames(); en.hasMoreElements();){
 	  addContextName((String)en.nextElement());
 	}
-	
+
 	for (Enumeration en = i.permissions(); en.hasMoreElements();){
-	  addPermission((java.security.acl.Permission)en.nextElement());
+	  addPermission((com.sun.jdmk.security.acl.Permission)en.nextElement());
 	}
 	if (i.isNegative()) setNegativePermissions();
   }
-  
+
   /**
    * Constructs an empty ACL entry.
    */
@@ -99,7 +99,7 @@ class AclEntryImpl implements AclEntry, Serializable {
 	permList = new Vector();
 	commList = new Vector();
   }
-  
+
   /**
    * Constructs an ACL entry with a specified principal.
    *
@@ -110,7 +110,7 @@ class AclEntryImpl implements AclEntry, Serializable {
 	permList = new Vector();
 	commList = new Vector();
   }
-  
+
   /**
    * Clones this ACL entry.
    *
@@ -121,7 +121,7 @@ class AclEntryImpl implements AclEntry, Serializable {
 	i = new AclEntryImpl(this);
 	return (Object) i;
   }
-  
+
   /**
    * Returns true if this is a negative ACL entry (one denying the associated principal
    * the set of permissions in the entry), false otherwise.
@@ -131,105 +131,105 @@ class AclEntryImpl implements AclEntry, Serializable {
   public boolean isNegative(){
 	return neg;
   }
-  
+
   /**
-   * Adds the specified permission to this ACL entry. Note: An entry can 
+   * Adds the specified permission to this ACL entry. Note: An entry can
    * have multiple permissions.
    *
-   * @param perm the permission to be associated with the principal in this 
+   * @param perm the permission to be associated with the principal in this
    * entry
-   * @return true if the permission is removed, false if the permission was 
-   * not part of this entry's permission set. 
+   * @return true if the permission is removed, false if the permission was
+   * not part of this entry's permission set.
    *
    */
-  public boolean addPermission(java.security.acl.Permission perm){
+  public boolean addPermission(com.sun.jdmk.security.acl.Permission perm){
 	if (permList.contains(perm)) return false;
 	permList.addElement(perm);
 	return true;
   }
-  
+
   /**
    * Removes the specified permission from this ACL entry.
    *
-   * @param perm the permission to be removed from this entry. 
+   * @param perm the permission to be removed from this entry.
    * @return true if the permission is removed, false if the permission
-   *  was not part of this entry's permission set. 
+   *  was not part of this entry's permission set.
    */
-  public boolean removePermission(java.security.acl.Permission perm){
+  public boolean removePermission(com.sun.jdmk.security.acl.Permission perm){
 	if (!permList.contains(perm)) return false;
 	permList.removeElement(perm);
 	return true;
   }
-  
+
   /**
-   * Checks if the specified permission is part of the permission set in 
-   * this entry. 
+   * Checks if the specified permission is part of the permission set in
+   * this entry.
    *
    * @param perm the permission to be checked for.
    * @return true if the permission is part of the permission set in this
-   * entry, false otherwise. 
+   * entry, false otherwise.
    */
-  
-  public boolean checkPermission(java.security.acl.Permission perm){
+
+  public boolean checkPermission(com.sun.jdmk.security.acl.Permission perm){
 	return (permList.contains(perm));
   }
-  
+
   /**
    * Returns an enumeration of the permissions in this ACL entry.
    *
-   * @return an enumeration of the permissions in this ACL entry. 
+   * @return an enumeration of the permissions in this ACL entry.
    */
   public Enumeration permissions(){
 	return permList.elements();
   }
-  
+
   /**
-   * Sets this ACL entry to be a negative one. That is, the associated principal 
+   * Sets this ACL entry to be a negative one. That is, the associated principal
    * (e.g., a user or a group) will be denied the permission set specified in the
    * entry. Note: ACL entries are by default positive. An entry becomes a negative
-   * entry only if this setNegativePermissions method is called on it. 
+   * entry only if this setNegativePermissions method is called on it.
    *
    * Not Implemented.
    */
   public void setNegativePermissions(){
 	neg = true;
   }
-  
+
   /**
    * Returns the principal for which permissions are granted or denied by this ACL
    * entry. Returns null if there is no principal set for this entry yet.
    *
-   * @return the principal associated with this entry. 
+   * @return the principal associated with this entry.
    */
   public Principal getPrincipal(){
 	return princ;
   }
-  
+
   /**
-   * Specifies the principal for which permissions are granted or denied by 
-   * this ACL entry. If a principal was already set for this ACL entry, 
-   * false is returned, otherwise true is returned. 
+   * Specifies the principal for which permissions are granted or denied by
+   * this ACL entry. If a principal was already set for this ACL entry,
+   * false is returned, otherwise true is returned.
    *
    * @param p the principal to be set for this entry.
-   * @return true if the principal is set, false if there was already a 
-   *    principal set for this entry. 
+   * @return true if the principal is set, false if there was already a
+   *    principal set for this entry.
    */
   public boolean setPrincipal(Principal p) {
-	if (princ != null ) 
+	if (princ != null )
 	  return false;
 	princ = p;
 	return true;
   }
-  
+
   /**
-   * Returns a string representation of the contents of this ACL entry. 
+   * Returns a string representation of the contents of this ACL entry.
    *
-   * @return a string representation of the contents. 
+   * @return a string representation of the contents.
    */
   public String toString(){
 	return "AclEntry:"+princ.toString();
   }
-  
+
   /**
    * Returns an enumeration of the communities in this ACL entry.
    *
@@ -238,51 +238,51 @@ class AclEntryImpl implements AclEntry, Serializable {
   public Enumeration contextNames(){
 	return commList.elements();
   }
-  
+
   /**
-   * Adds the specified community to this ACL entry. Note: An entry can have 
+   * Adds the specified community to this ACL entry. Note: An entry can have
    * multiple communities.
    *
-   * @param comm the community to be associated with the principal in this 
-   *    entry. 
-   * @return true if the community was added, false if the community was 
-   *    already part of this entry's community set. 
+   * @param comm the community to be associated with the principal in this
+   *    entry.
+   * @return true if the community was added, false if the community was
+   *    already part of this entry's community set.
    */
   public boolean addContextName(String comm){
 	if (commList.contains(comm)) return false;
 	commList.addElement(comm);
 	return true;
   }
-  
+
   /**
-   * Removes the specified community from this ACL entry. 
+   * Removes the specified community from this ACL entry.
    *
-   * @param comm the community  to be removed from this entry. 
-   * @return true if the community is removed, false if the community was 
-   *    not part of this entry's community set. 
+   * @param comm the community  to be removed from this entry.
+   * @return true if the community is removed, false if the community was
+   *    not part of this entry's community set.
    */
   public boolean removeContextName(String comm){
 	if (!commList.contains(comm)) return false;
 	commList.removeElement(comm);
 	return true;
   }
-  
+
   /**
-   * Checks if the specified community is part of the community set in 
-   * this entry. 
+   * Checks if the specified community is part of the community set in
+   * this entry.
    *
-   * @param comm the community to be checked for. 
-   * @return true if the community is part of the community set in this 
-   *   entry, false otherwise. 
+   * @param comm the community to be checked for.
+   * @return true if the community is part of the community set in this
+   *   entry, false otherwise.
    */
   public boolean checkContextName(String comm){
 	return (commList.contains(comm));
   }
-    
+
     /**
      * Checks if the specified security level is supported.
      *
-     * @param securityLevel The security level to check. 
+     * @param securityLevel The security level to check.
      * @return true if the security level is supported.
      */
     public boolean checkSecurityLevel(int securityLevel){
@@ -302,12 +302,3 @@ class AclEntryImpl implements AclEntry, Serializable {
     private Vector permList = null;
     private Vector commList = null;
 }
-
-
-
-
-
-
-
-
-

--- a/jdmkrt/snmp_manager/src/main/java/com/sun/management/snmp/uacl/AclImpl.java
+++ b/jdmkrt/snmp_manager/src/main/java/com/sun/management/snmp/uacl/AclImpl.java
@@ -4,19 +4,19 @@
  * @(#)version   1.10
  * @(#)lastedit  07/03/08
  *
- * 
+ *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
- * 
+ *
  * Copyright (c) 2007 Sun Microsystems, Inc. All Rights Reserved.
- * 
+ *
  * The contents of this file are subject to the terms of either the GNU General
  * Public License Version 2 only ("GPL") or the Common Development and
  * Distribution License("CDDL")(collectively, the "License"). You may not use
  * this file except in compliance with the License. You can obtain a copy of the
- * License at http://opendmk.dev.java.net/legal_notices/licenses.txt or in the 
- * LEGAL_NOTICES folder that accompanied this code. See the License for the 
+ * License at http://opendmk.dev.java.net/legal_notices/licenses.txt or in the
+ * LEGAL_NOTICES folder that accompanied this code. See the License for the
  * specific language governing permissions and limitations under the License.
- * 
+ *
  * When distributing the software, include this License Header Notice in each
  * file and include the License file found at
  *     http://opendmk.dev.java.net/legal_notices/licenses.txt
@@ -24,27 +24,27 @@
  * Sun designates this particular file as subject to the "Classpath" exception
  * as provided by Sun in the GPL Version 2 section of the License file that
  * accompanied this code.
- * 
+ *
  * If applicable, add the following below the License Header, with the fields
  * enclosed by brackets [] replaced by your own identifying information:
- * 
+ *
  *       "Portions Copyrighted [year] [name of copyright owner]"
- * 
+ *
  * Contributor(s):
- * 
+ *
  * If you wish your version of this file to be governed by only the CDDL or
  * only the GPL Version 2, indicate your decision by adding
- * 
+ *
  *       "[Contributor] elects to include this software in this distribution
  *        under the [CDDL or GPL Version 2] license."
- * 
+ *
  * If you don't indicate a single choice of license, a recipient has the option
  * to distribute your version of this file under either the CDDL or the GPL
  * Version 2, or to extend the choice of license to its licensees as provided
  * above. However, if you add GPL Version 2 code and therefore, elected the
  * GPL Version 2 license, then the option applies only if the new code is made
  * subject to such option by the copyright holder.
- * 
+ *
  *
  */
 
@@ -54,9 +54,9 @@ package com.sun.management.snmp.uacl;
 
 
 import java.security.Principal;
-import java.security.acl.Acl; 
-import java.security.acl.AclEntry; 
-import java.security.acl.NotOwnerException; 
+import com.sun.jdmk.security.acl.Acl;
+import com.sun.jdmk.security.acl.AclEntry;
+import com.sun.jdmk.security.acl.NotOwnerException;
 
 import java.io.Serializable;
 import java.util.Vector;
@@ -67,13 +67,13 @@ import java.util.Enumeration;
  * Represent an Access Control List (ACL) which is used to guard access to http adaptor.
  * <P>
  * It is a data structure with multiple ACL entries. Each ACL entry, of interface type
- * AclEntry, contains a set of permissions and a set of communities associated with a 
+ * AclEntry, contains a set of permissions and a set of communities associated with a
  * particular principal. (A principal represents an entity such as a host or a group of host).
  * Additionally, each ACL entry is specified as being either positive or negative.
  * If positive, the permissions are to be granted to the associated principal.
  * If negative, the permissions are to be denied.
  *
- * @see java.security.acl.Acl
+ * @see com.sun.jdmk.security.acl.Acl
  *
  * @since Java DMK 5.1
  */
@@ -82,7 +82,7 @@ class AclImpl extends OwnerImpl implements Acl, Serializable {
     private static final long serialVersionUID = -3477478331948334755L;
   private Vector entryList = null;
   private String aclName = null;
-  
+
   /**
    * Constructs the ACL with a specified owner
    *
@@ -94,90 +94,90 @@ class AclImpl extends OwnerImpl implements Acl, Serializable {
 	entryList = new Vector();
 	aclName = name;
   }
-  
+
   /**
    * Sets the name of this ACL.
    *
-   * @param caller the principal invoking this method. It must be an owner 
+   * @param caller the principal invoking this method. It must be an owner
    *    of this ACL.
-   * @param name the name to be given to this ACL. 
+   * @param name the name to be given to this ACL.
    *
    * @exception NotOwnerException if the caller principal is not an owner of
-   *    this ACL. 
+   *    this ACL.
    * @see java.security.Principal
    */
   public void setName(Principal caller, String name)
 	throws NotOwnerException {
 	  if (!isOwner(caller))
-		throw new NotOwnerException();	
+		throw new NotOwnerException();
 	  aclName = name;
   }
-  
+
   /**
-   * Returns the name of this ACL. 
+   * Returns the name of this ACL.
    *
-   * @return the name of this ACL. 
+   * @return the name of this ACL.
    */
   public String getName(){
 	return aclName;
   }
-  
+
   /**
    * Adds an ACL entry to this ACL. An entry associates a principal (e.g., an
-   * individual or a group) with a set of permissions. Each principal can 
-   * have at most one positive ACL entry (specifying permissions to be 
-   * granted to the principal) and one negative ACL entry (specifying 
-   * permissions to be denied). If there is already an ACL entry of the same 
-   * type (negative or positive) already in the ACL, false is returned. 
+   * individual or a group) with a set of permissions. Each principal can
+   * have at most one positive ACL entry (specifying permissions to be
+   * granted to the principal) and one negative ACL entry (specifying
+   * permissions to be denied). If there is already an ACL entry of the same
+   * type (negative or positive) already in the ACL, false is returned.
    *
    * @param caller the principal invoking this method. It must be an owner
-   *        of this ACL. 
-   * @param entry the ACL entry to be added to this ACL. 
-   * @return true on success, false if an entry of the same type (positive 
-   *     or negative) for the same principal is already present in this ACL. 
+   *        of this ACL.
+   * @param entry the ACL entry to be added to this ACL.
+   * @return true on success, false if an entry of the same type (positive
+   *     or negative) for the same principal is already present in this ACL.
    * @exception NotOwnerException if the caller principal is not an owner of
-   *    this ACL. 
+   *    this ACL.
    * @see java.security.Principal
    */
   public boolean addEntry(Principal caller, AclEntry entry)
 	throws NotOwnerException {
-	  if (!isOwner(caller)) 
+	  if (!isOwner(caller))
 		throw new NotOwnerException();
-	
+
 	  if (entryList.contains(entry))
 		return false;
-	  
+
 	  entryList.addElement(entry);
 	  return true;
   }
-  
+
   /**
-   * Removes an ACL entry from this ACL. 
+   * Removes an ACL entry from this ACL.
    *
-   * @param caller the principal invoking this method. It must be an owner 
-   *       of this ACL. 
-   * @param entry the ACL entry to be removed from this ACL. 
-   * @return true on success, false if the entry is not part of this ACL. 
+   * @param caller the principal invoking this method. It must be an owner
+   *       of this ACL.
+   * @param entry the ACL entry to be removed from this ACL.
+   * @return true on success, false if the entry is not part of this ACL.
    * @exception NotOwnerException if the caller principal is not an owner
-   *     of this Acl. 
+   *     of this Acl.
    * @see java.security.Principal
-   * @see java.security.acl.AclEntry
+   * @see com.sun.jdmk.security.acl.AclEntry
    */
   public boolean removeEntry(Principal caller, AclEntry entry)
 	throws NotOwnerException {
 	  if (!isOwner(caller))
 		throw new NotOwnerException();
-	  
+
 	  return (entryList.removeElement(entry));
   }
-  
+
   /**
    * Removes all ACL entries from this ACL.
    *
-   * @param caller the principal invoking this method. It must be an owner 
-   *    of this ACL. 
-   * @exception NotOwnerException if the caller principal is not an owner 
-   *    of this Acl. 
+   * @param caller the principal invoking this method. It must be an owner
+   *    of this ACL.
+   * @exception NotOwnerException if the caller principal is not an owner
+   *    of this Acl.
    * @see java.security.Principal
    */
   public void removeAll(Principal caller)
@@ -186,22 +186,22 @@ class AclImpl extends OwnerImpl implements Acl, Serializable {
 		throw new NotOwnerException();
 	entryList.removeAllElements();
   }
-  
+
   /**
-   * Returns an enumeration for the set of allowed permissions for the 
+   * Returns an enumeration for the set of allowed permissions for the
    * specified principal
    * (representing an entity such as an individual or a group).
    * This set of allowed permissions is calculated as follows:
    * <UL>
-   * <LI>If there is no entry in this Access Control List for the 
+   * <LI>If there is no entry in this Access Control List for the
    * specified principal, an empty permission set is returned.</LI>
-   * <LI>Otherwise, the principal's group permission sets are determined. 
+   * <LI>Otherwise, the principal's group permission sets are determined.
    * (A principal can belong to one or more groups, where a group is a group
    * of principals, represented by the Group interface.)</LI>
    * </UL>
-   * @param user the principal whose permission set is to be returned. 
-   * @return the permission set specifying the permissions the principal is 
-   *        allowed. 
+   * @param user the principal whose permission set is to be returned.
+   * @return the permission set specifying the permissions the principal is
+   *        allowed.
    * @see java.security.Principal
    */
   public Enumeration getPermissions(Principal user){
@@ -213,34 +213,34 @@ class AclImpl extends OwnerImpl implements Acl, Serializable {
 	}
 	return empty.elements();
   }
-  
+
   /**
    * Returns an enumeration of the entries in this ACL. Each element in the
-   * enumeration is of type AclEntry. 
+   * enumeration is of type AclEntry.
    *
-   * @return an enumeration of the entries in this ACL. 
+   * @return an enumeration of the entries in this ACL.
    */
   public Enumeration entries(){
 	return entryList.elements();
   }
-  
+
   /**
-   * Checks whether or not the specified principal has the specified 
-   * permission. If it does, true is returned, otherwise false is returned. 
+   * Checks whether or not the specified principal has the specified
+   * permission. If it does, true is returned, otherwise false is returned.
    * More specifically, this method checks whether the passed permission is a
-   * member of the allowed permission set of the specified principal. The 
-   * allowed permission set is determined by the same algorithm as is used 
-   * by the getPermissions method. 
+   * member of the allowed permission set of the specified principal. The
+   * allowed permission set is determined by the same algorithm as is used
+   * by the getPermissions method.
    *
-   * @param user the principal, assumed to be a valid authenticated Principal. 
-   * @param perm the permission to be checked for. 
-   * @return true if the principal has the specified permission, 
-   *         false otherwise. 
+   * @param user the principal, assumed to be a valid authenticated Principal.
+   * @param perm the permission to be checked for.
+   * @return true if the principal has the specified permission,
+   *         false otherwise.
    * @see java.security.Principal
    * @see java.security.Permission
    */
-  public boolean checkPermission(Principal user, 
-				 java.security.acl.Permission perm) {
+  public boolean checkPermission(Principal user,
+				 com.sun.jdmk.security.acl.Permission perm) {
 	for (Enumeration e = entryList.elements();e.hasMoreElements();){
 	  AclEntry ent = (AclEntry) e.nextElement();
 	  if (ent.getPrincipal().equals(user))
@@ -248,44 +248,44 @@ class AclImpl extends OwnerImpl implements Acl, Serializable {
 	}
 	return false;
   }
-  
+
   /**
-   * Checks whether or not the specified principal has the specified 
-   * permission. If it does, true is returned, otherwise false is returned. 
-   * More specifically, this method checks whether the passed permission is a 
-   * member of the allowed permission set of the specified principal. The 
-   * allowed permission set is determined by the same algorithm as is used 
-   * by the getPermissions method. 
+   * Checks whether or not the specified principal has the specified
+   * permission. If it does, true is returned, otherwise false is returned.
+   * More specifically, this method checks whether the passed permission is a
+   * member of the allowed permission set of the specified principal. The
+   * allowed permission set is determined by the same algorithm as is used
+   * by the getPermissions method.
    *
-   * @param user the principal, assumed to be a valid authenticated Principal. 
+   * @param user the principal, assumed to be a valid authenticated Principal.
    * @param community the community name associated with the principal.
-   * @param perm the permission to be checked for. 
-   * @return true if the principal has the specified permission, 
-   *         false otherwise. 
+   * @param perm the permission to be checked for.
+   * @return true if the principal has the specified permission,
+   *         false otherwise.
    * @see java.security.Principal
    * @see java.security.Permission
    */
-  public boolean checkPermission(Principal user, String community, 
-				 int securityLevel, 
-				 java.security.acl.Permission perm) {
+  public boolean checkPermission(Principal user, String community,
+				 int securityLevel,
+				 com.sun.jdmk.security.acl.Permission perm) {
 	for (Enumeration e = entryList.elements();e.hasMoreElements();){
 	  AclEntryImpl ent = (AclEntryImpl) e.nextElement();
 	  int sec = ent.getSecurityLevel();
 	  if (ent.getPrincipal().equals(user))
-		if (ent.checkPermission(perm) && 
+		if (ent.checkPermission(perm) &&
 		    ent.checkContextName(community) &&
 		    ent.checkSecurityLevel(securityLevel)) return true;
 	}
 	return false;
   }
-  
+
   /**
-   * Checks whether or not the specified community string is defined. 
+   * Checks whether or not the specified community string is defined.
    *
    * @param community the community name associated with the principal.
    *
    * @return true if the specified community string is defined,
-   *         false otherwise. 
+   *         false otherwise.
    * @see java.security.Principal
    * @see java.security.Permission
    */
@@ -296,19 +296,13 @@ class AclImpl extends OwnerImpl implements Acl, Serializable {
 	}
 	return false;
   }
-  
+
   /**
-   * Returns a string representation of the ACL contents. 
+   * Returns a string representation of the ACL contents.
    *
-   * @return a string representation of the ACL contents. 
+   * @return a string representation of the ACL contents.
    */
   public String toString(){
 	return ("AclImpl: "+ getName());
   }
 }
-
-
-
-
-
-

--- a/jdmkrt/snmp_manager/src/main/java/com/sun/management/snmp/uacl/GroupImpl.java
+++ b/jdmkrt/snmp_manager/src/main/java/com/sun/management/snmp/uacl/GroupImpl.java
@@ -4,19 +4,19 @@
  * @(#)version   1.9
  * @(#)lastedit  07/03/08
  *
- * 
+ *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
- * 
+ *
  * Copyright (c) 2007 Sun Microsystems, Inc. All Rights Reserved.
- * 
+ *
  * The contents of this file are subject to the terms of either the GNU General
  * Public License Version 2 only ("GPL") or the Common Development and
  * Distribution License("CDDL")(collectively, the "License"). You may not use
  * this file except in compliance with the License. You can obtain a copy of the
- * License at http://opendmk.dev.java.net/legal_notices/licenses.txt or in the 
- * LEGAL_NOTICES folder that accompanied this code. See the License for the 
+ * License at http://opendmk.dev.java.net/legal_notices/licenses.txt or in the
+ * LEGAL_NOTICES folder that accompanied this code. See the License for the
  * specific language governing permissions and limitations under the License.
- * 
+ *
  * When distributing the software, include this License Header Notice in each
  * file and include the License file found at
  *     http://opendmk.dev.java.net/legal_notices/licenses.txt
@@ -24,27 +24,27 @@
  * Sun designates this particular file as subject to the "Classpath" exception
  * as provided by Sun in the GPL Version 2 section of the License file that
  * accompanied this code.
- * 
+ *
  * If applicable, add the following below the License Header, with the fields
  * enclosed by brackets [] replaced by your own identifying information:
- * 
+ *
  *       "Portions Copyrighted [year] [name of copyright owner]"
- * 
+ *
  * Contributor(s):
- * 
+ *
  * If you wish your version of this file to be governed by only the CDDL or
  * only the GPL Version 2, indicate your decision by adding
- * 
+ *
  *       "[Contributor] elects to include this software in this distribution
  *        under the [CDDL or GPL Version 2] license."
- * 
+ *
  * If you don't indicate a single choice of license, a recipient has the option
  * to distribute your version of this file under either the CDDL or the GPL
  * Version 2, or to extend the choice of license to its licensees as provided
  * above. However, if you add GPL Version 2 code and therefore, elected the
  * GPL Version 2 license, then the option applies only if the new code is made
  * subject to such option by the copyright holder.
- * 
+ *
  *
  */
 
@@ -59,28 +59,28 @@ import java.io.Serializable;
 import java.net.UnknownHostException;
 
 
-import java.security.Principal; 
-import java.security.acl.Group; 
+import java.security.Principal;
+import com.sun.jdmk.security.acl.Group;
 
 
 /**
- * This class is used to represent a subnet mask (a group of hosts matching the same 
+ * This class is used to represent a subnet mask (a group of hosts matching the same
  * IP mask).
- * 
- * @see java.security.acl.Group
+ *
+ * @see com.sun.jdmk.security.acl.Group
  * @see java.security.Principal
  */
 
 class GroupImpl extends PrincipalImpl implements Group, Serializable {
     private static final long serialVersionUID = -8313979202179750837L;
-  
+
     /**
      * Constructs an empty group.
      * @exception UnknownHostException Not implemented
      */
     public GroupImpl () throws UnknownHostException {
     }
-  
+
     /**
      * Constructs a group using the specified subnet mask.
      *
@@ -90,30 +90,30 @@ class GroupImpl extends PrincipalImpl implements Group, Serializable {
     public GroupImpl (String mask) throws UnknownHostException {
 	super(mask);
     }
-  
+
     /**
-     * Adds the specified member to the group. 
+     * Adds the specified member to the group.
      *
-     * @param p the principal to add to this group. 
-     * @return true if the member was successfully added, false if the 
-     *     principal was already a member. 
+     * @param p the principal to add to this group.
+     * @return true if the member was successfully added, false if the
+     *     principal was already a member.
      */
     public boolean addMember(Principal p) {
-	// we don't need to add members because the ip address is a subnet 
-	// mask 
-	return true;	
+	// we don't need to add members because the ip address is a subnet
+	// mask
+	return true;
     }
 
     public int hashCode() {
-	return super.hashCode();	
+	return super.hashCode();
     }
-  
+
     /**
      * Compares this group to the specified object. Returns true if the object
      * passed in matches the group represented.
      *
      * @param p the object to compare with.
-     * @return true if the object passed in matches the subnet mask, 
+     * @return true if the object passed in matches the subnet mask,
      *         false otherwise.
      */
     public boolean equals (Object p) {
@@ -124,19 +124,19 @@ class GroupImpl extends PrincipalImpl implements Group, Serializable {
 	    return false;
 	}
     }
-  
+
     /**
      * Returns true if the passed principal is a member of the group.
      *
      * @param p the principal whose membership is to be checked.
-     * @return true if the principal is a member of this group, false 
-     *  otherwise. 
+     * @return true if the principal is a member of this group, false
+     *  otherwise.
      */
     public boolean isMember(Principal p) {
 	if ((p.hashCode() & super.hashCode()) == p.hashCode()) return true;
 	else return false;
     }
-  
+
     /**
      * Returns an enumeration which contains the subnet mask.
      *
@@ -147,7 +147,7 @@ class GroupImpl extends PrincipalImpl implements Group, Serializable {
 	v.addElement(this);
 	return v.elements();
     }
-  
+
     /**
      * Removes the specified member from the group. (Not implemented)
      *
@@ -157,7 +157,7 @@ class GroupImpl extends PrincipalImpl implements Group, Serializable {
     public boolean removeMember(Principal p) {
 	return true;
     }
-  
+
     /**
      * Prints a string representation of this group.
      *
@@ -167,5 +167,3 @@ class GroupImpl extends PrincipalImpl implements Group, Serializable {
 	return ("GroupImpl :"+super.getName());
     }
 }
-
-

--- a/jdmkrt/snmp_manager/src/main/java/com/sun/management/snmp/uacl/JdmkUserAcl.java
+++ b/jdmkrt/snmp_manager/src/main/java/com/sun/management/snmp/uacl/JdmkUserAcl.java
@@ -5,19 +5,19 @@
  * @(#)lastedit  07/03/08
  * @(#)build     @BUILD_TAG_PLACEHOLDER@
  *
- * 
+ *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
- * 
+ *
  * Copyright (c) 2007 Sun Microsystems, Inc. All Rights Reserved.
- * 
+ *
  * The contents of this file are subject to the terms of either the GNU General
  * Public License Version 2 only ("GPL") or the Common Development and
  * Distribution License("CDDL")(collectively, the "License"). You may not use
  * this file except in compliance with the License. You can obtain a copy of the
- * License at http://opendmk.dev.java.net/legal_notices/licenses.txt or in the 
- * LEGAL_NOTICES folder that accompanied this code. See the License for the 
+ * License at http://opendmk.dev.java.net/legal_notices/licenses.txt or in the
+ * LEGAL_NOTICES folder that accompanied this code. See the License for the
  * specific language governing permissions and limitations under the License.
- * 
+ *
  * When distributing the software, include this License Header Notice in each
  * file and include the License file found at
  *     http://opendmk.dev.java.net/legal_notices/licenses.txt
@@ -25,27 +25,27 @@
  * Sun designates this particular file as subject to the "Classpath" exception
  * as provided by Sun in the GPL Version 2 section of the License file that
  * accompanied this code.
- * 
+ *
  * If applicable, add the following below the License Header, with the fields
  * enclosed by brackets [] replaced by your own identifying information:
- * 
+ *
  *       "Portions Copyrighted [year] [name of copyright owner]"
- * 
+ *
  * Contributor(s):
- * 
+ *
  * If you wish your version of this file to be governed by only the CDDL or
  * only the GPL Version 2, indicate your decision by adding
- * 
+ *
  *       "[Contributor] elects to include this software in this distribution
  *        under the [CDDL or GPL Version 2] license."
- * 
+ *
  * If you don't indicate a single choice of license, a recipient has the option
  * to distribute your version of this file under either the CDDL or the GPL
  * Version 2, or to extend the choice of license to its licensees as provided
  * above. However, if you add GPL Version 2 code and therefore, elected the
  * GPL Version 2 license, then the option applies only if the new code is made
  * subject to such option by the copyright holder.
- * 
+ *
  */
 
 package com.sun.management.snmp.uacl;
@@ -63,8 +63,8 @@ import java.net.UnknownHostException;
 import java.util.Hashtable;
 import java.util.Vector;
 import java.util.Enumeration;
-import java.security.acl.AclEntry; 
-import java.security.acl.NotOwnerException; 
+import com.sun.jdmk.security.acl.AclEntry;
+import com.sun.jdmk.security.acl.NotOwnerException;
 
 // jdmk import
 //
@@ -95,10 +95,10 @@ import com.sun.management.snmp.UserAcl;
 
 public class JdmkUserAcl implements UserAcl, Serializable {
     private static final long serialVersionUID = 792943185727781789L;
-  
-    static final PermissionImpl READ  = new PermissionImpl("READ"); 
+
+    static final PermissionImpl READ  = new PermissionImpl("READ");
     static final PermissionImpl WRITE = new PermissionImpl("WRITE");
-  
+
     /**
      * Constructs the Java Dynamic Management(TM) Access Control List
      * based on user names. The ACL will take the given owner name.
@@ -109,11 +109,11 @@ public class JdmkUserAcl implements UserAcl, Serializable {
      * @param fileName The name of the ACL file.
      *
      */
-    public JdmkUserAcl(String name, String fileName) 
+    public JdmkUserAcl(String name, String fileName)
 	throws IllegalArgumentException {
 	trapDestList= new Hashtable();
         informDestList= new Hashtable();
-        
+
         // PrincipalImpl() take the current host as entry
         owner = new PrincipalImpl();
         try {
@@ -128,12 +128,12 @@ public class JdmkUserAcl implements UserAcl, Serializable {
 		      "the owner is built in this constructor");
             }
         }
-	
+
 	if(fileName == null)
 	    setDefautFileName();
 	else
 	    authorizedListFile = fileName;
-	
+
 	readAuthorisedListFile();
     }
 
@@ -148,17 +148,17 @@ public class JdmkUserAcl implements UserAcl, Serializable {
     public JdmkUserAcl(String name) throws IllegalArgumentException {
 	this(name, null);
     }
-  
+
     /**
      * Returns an enumeration of the entries in this ACL. Each element in the
-     * enumeration is of type <CODE>java.security.acl.AclEntry</CODE>.
+     * enumeration is of type <CODE>com.sun.jdmk.security.acl.AclEntry</CODE>.
      *
      * @return An enumeration of the entries in this ACL.
      */
     public synchronized Enumeration entries() {
         return acl.entries();
     }
-  
+
     /**
      * Returns the name of the ACL.
      *
@@ -167,7 +167,7 @@ public class JdmkUserAcl implements UserAcl, Serializable {
     public synchronized String getName() {
         return acl.getName();
     }
-  
+
     /**
      * Returns the read permission instance used.
      *
@@ -176,7 +176,7 @@ public class JdmkUserAcl implements UserAcl, Serializable {
     static public PermissionImpl getREAD() {
         return READ;
     }
-  
+
     /**
      * Returns the write permission instance used.
      *
@@ -185,7 +185,7 @@ public class JdmkUserAcl implements UserAcl, Serializable {
     static public PermissionImpl getWRITE() {
         return WRITE;
     }
-  
+
      /**
      * Sets the full path of the file containing the ACL information.
      * Setting a file makes the previous loaded ACL configuration to be cleared.
@@ -195,8 +195,8 @@ public class JdmkUserAcl implements UserAcl, Serializable {
      * @exception IllegalArgumentException If the passed ACL file is null or doesn't exist.
      * @exception NotOwnerException This exception is never thrown.
      */
-    public synchronized void setAuthorizedListFile(String filename)  
-	throws IllegalArgumentException, 
+    public synchronized void setAuthorizedListFile(String filename)
+	throws IllegalArgumentException,
 	       NotOwnerException {
 	if(filename == null)
 	    throw new IllegalArgumentException("The specified file is null");
@@ -215,7 +215,7 @@ public class JdmkUserAcl implements UserAcl, Serializable {
 
 	rereadTheFile();
     }
-    
+
     /**
      * Resets this ACL to the values contained in the configuration file.
      *
@@ -229,11 +229,11 @@ public class JdmkUserAcl implements UserAcl, Serializable {
         informDestList.clear();
         AclEntry ownEntry = new AclEntryImpl(owner);
         ownEntry.addPermission(READ);
-        ownEntry.addPermission(WRITE);  
+        ownEntry.addPermission(WRITE);
         acl.addEntry(owner,ownEntry);
         readAuthorisedListFile();
     }
-  
+
     /**
      * Returns the full path of the file used to get ACL information.
      *
@@ -242,7 +242,7 @@ public class JdmkUserAcl implements UserAcl, Serializable {
     public synchronized String getAuthorizedListFile() {
         return authorizedListFile;
     }
-  
+
     /**
      * Checks whether or not the specified user has <CODE>READ</CODE> access.
      *
@@ -255,7 +255,7 @@ public class JdmkUserAcl implements UserAcl, Serializable {
         PrincipalImpl p = new PrincipalImpl(user);
         return acl.checkPermission(p, READ);
     }
-    
+
     /**
      * Checks whether or not the specified user and context name have <CODE>READ</CODE> access.
      *
@@ -264,17 +264,17 @@ public class JdmkUserAcl implements UserAcl, Serializable {
      *
      * @return <CODE>true</CODE> if the pair (user, context) has read permission, <CODE>false</CODE> otherwise.
      */
-    public synchronized boolean checkReadPermission(String user, 
-						    String context, 
+    public synchronized boolean checkReadPermission(String user,
+						    String context,
 						    int securityLevel) {
         if (alwaysAuthorized) return ( true );
         PrincipalImpl p = new PrincipalImpl(user);
-	return acl.checkPermission(p, 
-				   context, 
+	return acl.checkPermission(p,
+				   context,
 				   securityLevel,
 				   READ);
     }
-  
+
     /**
      * Checks whether or not a context name is defined.
      *
@@ -285,7 +285,7 @@ public class JdmkUserAcl implements UserAcl, Serializable {
     public synchronized boolean checkContextName(String context) {
         return acl.checkContextName(context);
     }
-  
+
     /**
      * Checks whether or not the specified user has <CODE>WRITE</CODE> access.
      *
@@ -297,7 +297,7 @@ public class JdmkUserAcl implements UserAcl, Serializable {
         if (alwaysAuthorized) return ( true );
         PrincipalImpl p = new PrincipalImpl(user);
         return acl.checkPermission(p, WRITE);
-    } 
+    }
 
     /**
      * Checks whether or not the specified user and context name have <CODE>WRITE</CODE> access.
@@ -307,20 +307,20 @@ public class JdmkUserAcl implements UserAcl, Serializable {
      *
      * @return <CODE>true</CODE> if the pair (user, context) has write permission, <CODE>false</CODE> otherwise.
      */
-    public synchronized boolean checkWritePermission(String user, 
-						     String context, 
+    public synchronized boolean checkWritePermission(String user,
+						     String context,
 						     int securityLevel) {
         if (alwaysAuthorized) return ( true );
         PrincipalImpl p = new PrincipalImpl(user);
-	
-	return acl.checkPermission(p, 
-				   context, 
+
+	return acl.checkPermission(p,
+				   context,
 				   securityLevel,
 				   WRITE);
     }
 
     /**
-     * Fix for 6305089 and 6238234. Non readable file make ACL to throw 
+     * Fix for 6305089 and 6238234. Non readable file make ACL to throw
      * an exception.
      */
     private static void checkCanRead(String f) throws IllegalArgumentException {
@@ -329,7 +329,7 @@ public class JdmkUserAcl implements UserAcl, Serializable {
             throw new IllegalArgumentException("User ACL file is not " +
                     "readable.");
     }
-    
+
     /**
      * Converts the input configuration file into ACL.
      */
@@ -344,7 +344,7 @@ public class JdmkUserAcl implements UserAcl, Serializable {
             alwaysAuthorized = true ;
         } else {
             // Read the file content
-            Parser parser = null;  
+            Parser parser = null;
             try {
                 checkCanRead(getAuthorizedListFile());
                 parser= new Parser(new FileInputStream(getAuthorizedListFile()));
@@ -355,7 +355,7 @@ public class JdmkUserAcl implements UserAcl, Serializable {
                 alwaysAuthorized = true ;
                 return;
             }
-          
+
             try {
                 JDMSecurityDefs n = parser.SecurityDefs();
                 n.buildAclEntries(owner, acl);
@@ -363,31 +363,31 @@ public class JdmkUserAcl implements UserAcl, Serializable {
                 n.buildInformEntries(informDestList);
             } catch (ParseException e) {
                 if (logger.finestOn()) {
-                    logger.finest("readAuthorisedListFile", 
+                    logger.finest("readAuthorisedListFile",
 				  "Parsing exception " + e);
                 }
-		final IllegalArgumentException ie = 
+		final IllegalArgumentException ie =
 		    new IllegalArgumentException("Syntax error: "+e);
 		Utils.initCause(ie,e);
 		throw ie;
             } catch (Error err) {
                 if (logger.finestOn()) {
-                    logger.finest("readAuthorisedListFile", 
+                    logger.finest("readAuthorisedListFile",
 				  "Error exception " + err);
                 }
-		final IllegalArgumentException ie = 
+		final IllegalArgumentException ie =
 		    new IllegalArgumentException("Error: " + err);
 		Utils.initCause(ie,err);
 		throw ie;
             }
-          
+
             for(Enumeration e = acl.entries(); e.hasMoreElements();) {
                 AclEntryImpl aa = (AclEntryImpl) e.nextElement();
                 if (logger.finerOn()) {
                     logger.finer("readAuthorisedListFile", "===> " + aa.getPrincipal().toString());
                 }
                 for (Enumeration eee = aa.permissions();eee.hasMoreElements();) {
-                    java.security.acl.Permission perm = (java.security.acl.Permission)eee.nextElement();
+                    com.sun.jdmk.security.acl.Permission perm = (com.sun.jdmk.security.acl.Permission)eee.nextElement();
                     if (logger.finerOn()) {
                         logger.finer("readAuthorisedListFile", "perm = " + perm);
                     }
@@ -395,24 +395,24 @@ public class JdmkUserAcl implements UserAcl, Serializable {
             }
         }
     }
-  
+
     /**
      * Set the default full path for "jdmk.uacl" input file.
      */
     private void setDefautFileName() throws IllegalArgumentException {
-	String aclFile = null;	
+	String aclFile = null;
 	File file = null;
-	
+
         if ((aclFile = (String) System.getProperty(JdmkProperties.UACL_FILE)) == null) {
             aclFile = DefaultPaths.getEtcDir("conf" + File.separator + "jdmk.uacl");
 	    if (logger.finestOn())
-		logger.finest("setDefautFileName", 
+		logger.finest("setDefautFileName",
 		      "Default File name is : " + aclFile);
-	    
+
 	    file = new File(aclFile);
 	    if (file.isFile()) {
 		if (logger.finerOn()) {
-		    logger.finer("setDefautFileName", 
+		    logger.finer("setDefautFileName",
 			  "Default User ACL file found : " + aclFile);
 		}
 	    } else {
@@ -433,22 +433,22 @@ public class JdmkUserAcl implements UserAcl, Serializable {
 		if (logger.finerOn()) {
 		    logger.finer("setDefautFileName", "User ACL file found : " + aclFile);
 		}
-	}    
+	}
 	authorizedListFile = aclFile;
     }
-  
-    
+
+
     // TRACES & DEBUG
     //---------------
-    
-    private static final ClassLogger logger = 
+
+    private static final ClassLogger logger =
 	new ClassLogger(ClassLogger.LOGGER_SNMP,"JdmkUserAcl");
-    
+
     String dbgTag = "JdmkUserAcl";
-    
+
     // PRIVATE VARIABLES
     //------------------
-    
+
     /**
      * Represents the Access Control List.
      */
@@ -470,6 +470,6 @@ public class JdmkUserAcl implements UserAcl, Serializable {
      * Contains the hosts list for inform destination.
      */
     private Hashtable informDestList = null;
-    
+
     private PrincipalImpl owner = null;
 }

--- a/jdmkrt/snmp_manager/src/main/java/com/sun/management/snmp/uacl/OwnerImpl.java
+++ b/jdmkrt/snmp_manager/src/main/java/com/sun/management/snmp/uacl/OwnerImpl.java
@@ -4,19 +4,19 @@
  * @(#)version   1.9
  * @(#)date      07/03/08
  *
- * 
+ *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
- * 
+ *
  * Copyright (c) 2007 Sun Microsystems, Inc. All Rights Reserved.
- * 
+ *
  * The contents of this file are subject to the terms of either the GNU General
  * Public License Version 2 only ("GPL") or the Common Development and
  * Distribution License("CDDL")(collectively, the "License"). You may not use
  * this file except in compliance with the License. You can obtain a copy of the
- * License at http://opendmk.dev.java.net/legal_notices/licenses.txt or in the 
- * LEGAL_NOTICES folder that accompanied this code. See the License for the 
+ * License at http://opendmk.dev.java.net/legal_notices/licenses.txt or in the
+ * LEGAL_NOTICES folder that accompanied this code. See the License for the
  * specific language governing permissions and limitations under the License.
- * 
+ *
  * When distributing the software, include this License Header Notice in each
  * file and include the License file found at
  *     http://opendmk.dev.java.net/legal_notices/licenses.txt
@@ -24,27 +24,27 @@
  * Sun designates this particular file as subject to the "Classpath" exception
  * as provided by Sun in the GPL Version 2 section of the License file that
  * accompanied this code.
- * 
+ *
  * If applicable, add the following below the License Header, with the fields
  * enclosed by brackets [] replaced by your own identifying information:
- * 
+ *
  *       "Portions Copyrighted [year] [name of copyright owner]"
- * 
+ *
  * Contributor(s):
- * 
+ *
  * If you wish your version of this file to be governed by only the CDDL or
  * only the GPL Version 2, indicate your decision by adding
- * 
+ *
  *       "[Contributor] elects to include this software in this distribution
  *        under the [CDDL or GPL Version 2] license."
- * 
+ *
  * If you don't indicate a single choice of license, a recipient has the option
  * to distribute your version of this file under either the CDDL or the GPL
  * Version 2, or to extend the choice of license to its licensees as provided
  * above. However, if you add GPL Version 2 code and therefore, elected the
  * GPL Version 2 license, then the option applies only if the new code is made
  * subject to such option by the copyright holder.
- * 
+ *
  *
  */
 
@@ -57,9 +57,9 @@ import java.util.Vector;
 import java.io.Serializable;
 
 import java.security.Principal;
-import java.security.acl.Owner; 
-import java.security.acl.LastOwnerException; 
-import java.security.acl.NotOwnerException; 
+import com.sun.jdmk.security.acl.Owner;
+import com.sun.jdmk.security.acl.LastOwnerException;
+import com.sun.jdmk.security.acl.NotOwnerException;
 
 
 /**
@@ -67,7 +67,7 @@ import java.security.acl.NotOwnerException;
  * The initial owner Principal should be specified as an
  * argument to the constructor of the class AclImpl.
  *
- * @see java.security.acl.Owner
+ * @see com.sun.jdmk.security.acl.Owner
  *
  * @since Java DMK 5.1
  */
@@ -75,16 +75,16 @@ import java.security.acl.NotOwnerException;
 class OwnerImpl implements Owner, Serializable {
     private static final long serialVersionUID = 6554169470971658903L;
     private Vector ownerList = null;
-  
+
     /**
      * Constructs an empty list of owner.
      */
     public OwnerImpl (){
 	ownerList = new Vector();
     }
-  
+
     /**
-     * Constructs a list of owner with the specified principal as first 
+     * Constructs a list of owner with the specified principal as first
      * element.
      *
      * @param owner the principal added to the owner list.
@@ -93,25 +93,25 @@ class OwnerImpl implements Owner, Serializable {
 	ownerList = new Vector();
 	ownerList.addElement(owner);
     }
-  
+
     /**
      * Adds an owner. Only owners can modify ACL contents. The caller principal
-     * must be an owner of the ACL in order to invoke this method. That is, 
+     * must be an owner of the ACL in order to invoke this method. That is,
      * only an owner can add another owner. The initial owner is configured at
      * ACL construction time.
      *
-     * @param caller the principal invoking this method. It must be an owner 
+     * @param caller the principal invoking this method. It must be an owner
      *        of the ACL.
      * @param owner the owner that should be added to the list of owners.
-     * @return true if successful, false if owner is already an owner. 
-     * @exception NotOwnerException if the caller principal is not an owner of 
-     *  the ACL. 
+     * @return true if successful, false if owner is already an owner.
+     * @exception NotOwnerException if the caller principal is not an owner of
+     *  the ACL.
      */
-    public boolean addOwner(Principal caller, Principal owner) 
+    public boolean addOwner(Principal caller, Principal owner)
 	throws NotOwnerException {
-	if (!ownerList.contains(caller)) 
+	if (!ownerList.contains(caller))
 	    throw new NotOwnerException();
-	
+
 	if (ownerList.contains(owner)) {
 	    return false;
 	} else {
@@ -119,20 +119,20 @@ class OwnerImpl implements Owner, Serializable {
 	    return true;
 	}
     }
-  
+
     /**
-     * Deletes an owner. If this is the last owner in the ACL, an exception is 
+     * Deletes an owner. If this is the last owner in the ACL, an exception is
      * raised.
-     *<P> The caller principal must be an owner of the ACL in order to invoke 
-     * this method.</P> 
+     *<P> The caller principal must be an owner of the ACL in order to invoke
+     * this method.</P>
      *
      * @param caller the principal invoking this method. It must be an owner of
-     *        the ACL. 
-     * @param owner the owner to be removed from the list of owners. 
-     * @return true if successful, false if owner is already an owner. 
-     * @exception NotOwnerException if the caller principal is not an owner of 
-     *            the ACL. 
-     * @exception LastOwnerException if there is only one owner left, so that 
+     *        the ACL.
+     * @param owner the owner to be removed from the list of owners.
+     * @return true if successful, false if owner is already an owner.
+     * @exception NotOwnerException if the caller principal is not an owner of
+     *            the ACL.
+     * @exception LastOwnerException if there is only one owner left, so that
      *            deleteOwner would leave the ACL owner-less.
      */
     public boolean deleteOwner(Principal caller, Principal owner)
@@ -140,23 +140,23 @@ class OwnerImpl implements Owner, Serializable {
 
 	if (!ownerList.contains(caller))
 	    throw new NotOwnerException();
-	
+
 	if (!ownerList.contains(owner)){
 	    return false;
 	} else {
 	    if (ownerList.size() == 1)
 		throw new LastOwnerException();
-	    
+
 	    ownerList.removeElement(owner);
 	    return true;
 	}
     }
-  
+
     /**
      * Returns true if the given principal is an owner of the ACL.
      *
      * @param owner the principal to be checked to determine whether
-     *        or not it is an owner. 
+     *        or not it is an owner.
      * @return true if the given principal is an owner of the ACL.
      */
     public boolean isOwner(Principal owner){

--- a/jdmkrt/snmp_manager/src/main/java/com/sun/management/snmp/uacl/PermissionImpl.java
+++ b/jdmkrt/snmp_manager/src/main/java/com/sun/management/snmp/uacl/PermissionImpl.java
@@ -4,19 +4,19 @@
  * @(#)version   1.10
  * @(#)lastedit  07/03/08
  *
- * 
+ *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
- * 
+ *
  * Copyright (c) 2007 Sun Microsystems, Inc. All Rights Reserved.
- * 
+ *
  * The contents of this file are subject to the terms of either the GNU General
  * Public License Version 2 only ("GPL") or the Common Development and
  * Distribution License("CDDL")(collectively, the "License"). You may not use
  * this file except in compliance with the License. You can obtain a copy of the
- * License at http://opendmk.dev.java.net/legal_notices/licenses.txt or in the 
- * LEGAL_NOTICES folder that accompanied this code. See the License for the 
+ * License at http://opendmk.dev.java.net/legal_notices/licenses.txt or in the
+ * LEGAL_NOTICES folder that accompanied this code. See the License for the
  * specific language governing permissions and limitations under the License.
- * 
+ *
  * When distributing the software, include this License Header Notice in each
  * file and include the License file found at
  *     http://opendmk.dev.java.net/legal_notices/licenses.txt
@@ -24,27 +24,27 @@
  * Sun designates this particular file as subject to the "Classpath" exception
  * as provided by Sun in the GPL Version 2 section of the License file that
  * accompanied this code.
- * 
+ *
  * If applicable, add the following below the License Header, with the fields
  * enclosed by brackets [] replaced by your own identifying information:
- * 
+ *
  *       "Portions Copyrighted [year] [name of copyright owner]"
- * 
+ *
  * Contributor(s):
- * 
+ *
  * If you wish your version of this file to be governed by only the CDDL or
  * only the GPL Version 2, indicate your decision by adding
- * 
+ *
  *       "[Contributor] elects to include this software in this distribution
  *        under the [CDDL or GPL Version 2] license."
- * 
+ *
  * If you don't indicate a single choice of license, a recipient has the option
  * to distribute your version of this file under either the CDDL or the GPL
  * Version 2, or to extend the choice of license to its licensees as provided
  * above. However, if you add GPL Version 2 code and therefore, elected the
  * GPL Version 2 license, then the option applies only if the new code is made
  * subject to such option by the copyright holder.
- * 
+ *
  *
  */
 package com.sun.management.snmp.uacl;
@@ -62,10 +62,10 @@ import java.io.Serializable;
  * @since Java DMK 5.1
  */
 
-class PermissionImpl implements java.security.acl.Permission, Serializable {
+class PermissionImpl implements com.sun.jdmk.security.acl.Permission, Serializable {
     private static final long serialVersionUID = 6258033248566573269L;
     private String perm = null;
-  
+
     /**
      * Constructs a permission.
      *
@@ -74,17 +74,17 @@ class PermissionImpl implements java.security.acl.Permission, Serializable {
     public PermissionImpl(String s) {
 	perm = s;
     }
-  
+
     public int hashCode() {
 	if (perm == null) return 0;
-	return perm.hashCode();	
+	return perm.hashCode();
     }
-  
+
     /**
-     * Returns true if the object passed matches the permission represented 
-     * in. 
+     * Returns true if the object passed matches the permission represented
+     * in.
      *
-     * @param p the Permission object to compare with. 
+     * @param p the Permission object to compare with.
      * @return true if the Permission objects are equal, false otherwise.
      */
     public boolean equals(Object p){
@@ -94,23 +94,22 @@ class PermissionImpl implements java.security.acl.Permission, Serializable {
 	    return false;
 	}
     }
-  
+
     /**
-     * Prints a string representation of this permission. 
+     * Prints a string representation of this permission.
      *
-     * @return a string representation of this permission. 
+     * @return a string representation of this permission.
      */
     public String toString(){
 	return perm.toString();
     }
-  
+
     /**
-     * Prints the permission. 
+     * Prints the permission.
      *
-     * @return a string representation of this permission. 
+     * @return a string representation of this permission.
      */
     public String getString(){
 	return perm;
     }
 }
-

--- a/jdmkrt/snmp_manager/src/main/java/com/sun/management/snmp/uacl/User.java
+++ b/jdmkrt/snmp_manager/src/main/java/com/sun/management/snmp/uacl/User.java
@@ -5,19 +5,19 @@
  * @(#)lastedit  07/03/08
  * @(#)build     @BUILD_TAG_PLACEHOLDER@
  *
- * 
+ *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
- * 
+ *
  * Copyright (c) 2007 Sun Microsystems, Inc. All Rights Reserved.
- * 
+ *
  * The contents of this file are subject to the terms of either the GNU General
  * Public License Version 2 only ("GPL") or the Common Development and
  * Distribution License("CDDL")(collectively, the "License"). You may not use
  * this file except in compliance with the License. You can obtain a copy of the
- * License at http://opendmk.dev.java.net/legal_notices/licenses.txt or in the 
- * LEGAL_NOTICES folder that accompanied this code. See the License for the 
+ * License at http://opendmk.dev.java.net/legal_notices/licenses.txt or in the
+ * LEGAL_NOTICES folder that accompanied this code. See the License for the
  * specific language governing permissions and limitations under the License.
- * 
+ *
  * When distributing the software, include this License Header Notice in each
  * file and include the License file found at
  *     http://opendmk.dev.java.net/legal_notices/licenses.txt
@@ -25,27 +25,27 @@
  * Sun designates this particular file as subject to the "Classpath" exception
  * as provided by Sun in the GPL Version 2 section of the License file that
  * accompanied this code.
- * 
+ *
  * If applicable, add the following below the License Header, with the fields
  * enclosed by brackets [] replaced by your own identifying information:
- * 
+ *
  *       "Portions Copyrighted [year] [name of copyright owner]"
- * 
+ *
  * Contributor(s):
- * 
+ *
  * If you wish your version of this file to be governed by only the CDDL or
  * only the GPL Version 2, indicate your decision by adding
- * 
+ *
  *       "[Contributor] elects to include this software in this distribution
  *        under the [CDDL or GPL Version 2] license."
- * 
+ *
  * If you don't indicate a single choice of license, a recipient has the option
  * to distribute your version of this file under either the CDDL or the GPL
  * Version 2, or to extend the choice of license to its licensees as provided
  * above. However, if you add GPL Version 2 code and therefore, elected the
  * GPL Version 2 license, then the option applies only if the new code is made
  * subject to such option by the copyright holder.
- * 
+ *
  */
 
 
@@ -60,13 +60,13 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Hashtable;
 import java.util.Vector;
-import java.security.acl.NotOwnerException;
+import com.sun.jdmk.security.acl.NotOwnerException;
 
 // jdmk import
 //
 import com.sun.jdmk.internal.ClassLogger;
 
-  
+
 /**
  * The class defines an abstract representation of a host.
  *
@@ -74,7 +74,7 @@ import com.sun.jdmk.internal.ClassLogger;
  * @since Java DMK 5.1
  */
 abstract class User extends SimpleNode implements Serializable {
-  
+
     public User(int id) {
         super(id);
     }
@@ -82,17 +82,17 @@ abstract class User extends SimpleNode implements Serializable {
     public User(Parser p, int id) {
         super(p, id);
     }
-  
+
     protected abstract PrincipalImpl createAssociatedPrincipal();
-  
+
     protected abstract String getName();
-    
+
     public void buildAclEntries(PrincipalImpl owner, AclImpl acl) {
         // Create a principal
         //
         PrincipalImpl p=null;
 	p = createAssociatedPrincipal();
-	
+
         // Create an AclEntry
         //
         AclEntryImpl entry= null;
@@ -104,7 +104,7 @@ abstract class User extends SimpleNode implements Serializable {
 	    acl.addEntry(owner, entry);
 	} catch(NotOwnerException a) {
             if (logger.finestOn()) {
-                logger.finest("buildAclEntries", "Not owner of ACL " + 
+                logger.finest("buildAclEntries", "Not owner of ACL " +
 			      a);
             }
             return;
@@ -112,7 +112,7 @@ abstract class User extends SimpleNode implements Serializable {
     }
 
     private void registerPermission(AclEntryImpl entry) {
-        //JDMUsers user = (JDMUser) jjtGetParent(); 
+        //JDMUsers user = (JDMUser) jjtGetParent();
         JDMUsers users= (JDMUsers) jjtGetParent();
         JDMAclItem acl= (JDMAclItem) users.jjtGetParent();
         JDMAccess access= (JDMAccess) acl.getAccess();
@@ -121,11 +121,11 @@ abstract class User extends SimpleNode implements Serializable {
 	secLevel.setSecurityLevel(entry);
         JDMContextNames comm= (JDMContextNames) acl.getContextNames();
         comm.buildContextNames(entry);
-    } 
+    }
 
     // Logging
     //--------
-    private static final ClassLogger logger = 
+    private static final ClassLogger logger =
 	new ClassLogger(ClassLogger.LOGGER_SNMP,"User");
 
     String dbgTag = "User";

--- a/jdmktk/jdmktk-dist/pom.xml
+++ b/jdmktk/jdmktk-dist/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.xtreemfs.opendmk</groupId>
     <artifactId>opendmk-jdmktk</artifactId>
-    <version>1.0-b03-SNAPSHOT</version>
+    <version>1.1-b02-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/jdmktk/jdmktk-dist/pom.xml
+++ b/jdmktk/jdmktk-dist/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.xtreemfs.opendmk</groupId>
     <artifactId>opendmk-jdmktk</artifactId>
-    <version>1.0-b02-SNAPSHOT</version>
+    <version>1.0-b03-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/jdmktk/pom.xml
+++ b/jdmktk/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.xtreemfs.opendmk</groupId>
     <artifactId>opendmk-parent</artifactId>
-    <version>1.0-b02-SNAPSHOT</version>
+    <version>1.0-b03-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/jdmktk/pom.xml
+++ b/jdmktk/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.xtreemfs.opendmk</groupId>
     <artifactId>opendmk-parent</artifactId>
-    <version>1.0-b03-SNAPSHOT</version>
+    <version>1.1-b02-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/jdmktk/toolkit/pom.xml
+++ b/jdmktk/toolkit/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.xtreemfs.opendmk</groupId>
     <artifactId>opendmk-jdmktk</artifactId>
-    <version>1.0-b03-SNAPSHOT</version>
+    <version>1.1-b02-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/jdmktk/toolkit/pom.xml
+++ b/jdmktk/toolkit/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.xtreemfs.opendmk</groupId>
     <artifactId>opendmk-jdmktk</artifactId>
-    <version>1.0-b02-SNAPSHOT</version>
+    <version>1.0-b03-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/jmxremote_optional/jmx_optional/pom.xml
+++ b/jmxremote_optional/jmx_optional/pom.xml
@@ -5,12 +5,20 @@
   <parent>
     <groupId>org.xtreemfs.opendmk</groupId>
     <artifactId>opendmk-jmxremote_optional</artifactId>
-    <version>1.0-b02-SNAPSHOT</version>
+    <version>1.0-b03-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 
   <artifactId>jmx_optional</artifactId>
   <name>jmx_optional</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.ow2.jonas.osgi</groupId>
+      <artifactId>corba-api</artifactId>
+      <version>5.0.1</version>
+    </dependency>
+  </dependencies>
 
   <packaging>jar</packaging>
 </project>

--- a/jmxremote_optional/jmx_optional/pom.xml
+++ b/jmxremote_optional/jmx_optional/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.xtreemfs.opendmk</groupId>
     <artifactId>opendmk-jmxremote_optional</artifactId>
-    <version>1.0-b03-SNAPSHOT</version>
+    <version>1.1-b02-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/jmxremote_optional/jmxremote_optional-dist/pom.xml
+++ b/jmxremote_optional/jmxremote_optional-dist/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.xtreemfs.opendmk</groupId>
     <artifactId>opendmk-jmxremote_optional</artifactId>
-    <version>1.0-b02-SNAPSHOT</version>
+    <version>1.0-b03-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/jmxremote_optional/jmxremote_optional-dist/pom.xml
+++ b/jmxremote_optional/jmxremote_optional-dist/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.xtreemfs.opendmk</groupId>
     <artifactId>opendmk-jmxremote_optional</artifactId>
-    <version>1.0-b03-SNAPSHOT</version>
+    <version>1.1-b02-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/jmxremote_optional/pom.xml
+++ b/jmxremote_optional/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.xtreemfs.opendmk</groupId>
     <artifactId>opendmk-parent</artifactId>
-    <version>1.0-b02-SNAPSHOT</version>
+    <version>1.0-b03-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/jmxremote_optional/pom.xml
+++ b/jmxremote_optional/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.xtreemfs.opendmk</groupId>
     <artifactId>opendmk-parent</artifactId>
-    <version>1.0-b03-SNAPSHOT</version>
+    <version>1.1-b02-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.xtreemfs.opendmk</groupId>
   <artifactId>opendmk-parent</artifactId>
-  <version>1.0-b03-SNAPSHOT</version>
+  <version>1.1-b02-SNAPSHOT</version>
 
   <name>opendmk</name>
   <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.xtreemfs.opendmk</groupId>
   <artifactId>opendmk-parent</artifactId>
-  <version>1.0-b02-SNAPSHOT</version>
+  <version>1.0-b03-SNAPSHOT</version>
 
   <name>opendmk</name>
   <packaging>pom</packaging>
@@ -49,6 +49,16 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.1</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+      </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>


### PR DESCRIPTION
Hello,

Thanks for placing opendmk on GitHub. The pull request contains the changes necessary to compile the code with JDK 14 and byte code level 1.8. I added a dependency for CORBA since that is no longer included with JDK 14. I also added replacements for java.security.acl since that has been removed from JDK 14 too. You can find the replacement interfaces in jdmkrt/core/src/main/java/com/sun/jdmk/security/acl. I had looked at trying to use the java.security.Policy related classes, but adding the interfaces looked more straightforward. Thanks.