### PR TITLE
Support AES Algorithm as per RFC3826

### DIFF
--- a/jdmkrt/snmp_manager/src/main/java/com/sun/management/internal/snmp/SnmpEncryptionPair.java
+++ b/jdmkrt/snmp_manager/src/main/java/com/sun/management/internal/snmp/SnmpEncryptionPair.java
@@ -62,4 +62,8 @@ public class SnmpEncryptionPair {
      * Encryption parameters. 
      */
     public byte[] parameters = null;
+    
+    public int authoritativeEngineBoots;
+
+    public int authoritativeEngineTime;
 }

--- a/jdmkrt/snmp_manager/src/main/java/com/sun/management/snmp/usm/SnmpUsmPrivModule.java
+++ b/jdmkrt/snmp_manager/src/main/java/com/sun/management/snmp/usm/SnmpUsmPrivModule.java
@@ -171,6 +171,11 @@ class SnmpUsmPrivModule {
 	    SnmpEncryptionPair pair = new SnmpEncryptionPair();
 	    pair.encryptedData = encryptedData;
 	    pair.parameters = params.getPrivParameters();
+	    
+	    //Required to support AES Algorithm as per RFC 3826 to calculate IV
+	    pair.authoritativeEngineBoots = params.getAuthoritativeEngineBoots();
+	    pair.authoritativeEngineTime = params.getAuthoritativeEngineTime();
+	    
 	    //Ask the algo to decrypt.
 	    byte []data = privPair.algo.decrypt(privPair.key, 
 						pair);


### PR DESCRIPTION
To support AES Algorithm as per RFC3826 EngineBoots and EngineTime are required to calculate IV
IV is calculated with concatinated boots+enginetime+securityprivacyparameter
But there is no provision for the AES algorithm to receive this information
hence the algorithm that implements SnmpUsmPrivAlgorithm for usmAesCfb128PrivProtocol 
is passed these parameters from SnmpUsmPrivModule.decrypt through the SnmpEncryptionPair 
https://datatracker.ietf.org/doc/html/rfc3826
@robert-schmidtke Please review